### PR TITLE
Rewrite theme registry service

### DIFF
--- a/registry/src/services/themes/defaults.ts
+++ b/registry/src/services/themes/defaults.ts
@@ -1,6 +1,8 @@
-import type { ThemesModel } from './model';
+import type { ThemeDraft, ThemeRecord } from './model';
 
-export const defaultThemes: ThemesModel['publishBody'][] = [
+const DEFAULT_THEME_TIMESTAMP = '2026-04-04T00:00:00.000Z';
+
+export const defaultThemes: ThemeDraft[] = [
 	{
 		slug: 'default',
 		name: 'Default',
@@ -33,6 +35,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#c9d1dc',
 			input: '#c9d1dc',
 			primary: '#155eef',
+			info: '#2563eb',
 			foregroundOpposite: '#ffffff',
 			foreground: '#101828',
 			muted: '#f2f4f7',
@@ -56,6 +59,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#282f3a',
 			input: '#262d38',
 			primary: '#528bff',
+			info: '#60a5fa',
 			foregroundOpposite: '#ffffff',
 			foreground: '#eef2f8',
 			muted: '#101419',
@@ -106,6 +110,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#cdbfae',
 			input: '#d8cbbb',
 			primary: '#a44a2f',
+			info: '#3170b8',
 			foregroundOpposite: '#ffffff',
 			foreground: '#271d19',
 			muted: '#f6efe7',
@@ -129,6 +134,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#372f29',
 			input: '#342b26',
 			primary: '#f08f69',
+			info: '#8cb4ef',
 			foregroundOpposite: '#ffffff',
 			foreground: '#f4ece6',
 			muted: '#171310',
@@ -179,6 +185,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#c2d0bb',
 			input: '#c7d5c1',
 			primary: '#2f7a54',
+			info: '#2f6fb8',
 			foregroundOpposite: '#ffffff',
 			foreground: '#18261d',
 			muted: '#f1f5ee',
@@ -202,6 +209,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#283229',
 			input: '#273228',
 			primary: '#63c08c',
+			info: '#7fb6ef',
 			foregroundOpposite: '#ffffff',
 			foreground: '#edf5ef',
 			muted: '#111711',
@@ -252,6 +260,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#d7dee8',
 			input: '#d7dee8',
 			primary: '#4d607f',
+			info: '#2563eb',
 			foregroundOpposite: '#ffffff',
 			foreground: '#111827',
 			muted: '#f4f6fa',
@@ -275,6 +284,7 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 			borderStrong: '#2b3442',
 			input: '#293240',
 			primary: '#4d607f',
+			info: '#7aa8ff',
 			foregroundOpposite: '#ffffff',
 			foreground: '#eef2f8',
 			muted: '#10151d',
@@ -294,3 +304,22 @@ export const defaultThemes: ThemesModel['publishBody'][] = [
 		}
 	}
 ];
+
+const DEFAULT_SLUGS: ReadonlySet<string> = new Set(defaultThemes.map((theme) => theme.slug));
+
+export function isDefaultSlug(slug: string): boolean {
+	return DEFAULT_SLUGS.has(slug);
+}
+
+export function findDefaultTheme(slug: string): ThemeDraft | undefined {
+	return defaultThemes.find((theme) => theme.slug === slug);
+}
+
+export function defaultThemeRecord(theme: ThemeDraft): ThemeRecord {
+	return {
+		...theme,
+		id: `default:${theme.slug}`,
+		createdAt: DEFAULT_THEME_TIMESTAMP,
+		updatedAt: DEFAULT_THEME_TIMESTAMP
+	};
+}

--- a/registry/src/services/themes/index.ts
+++ b/registry/src/services/themes/index.ts
@@ -1,42 +1,36 @@
 import { Elysia } from 'elysia';
-import { ThemesModel } from './model';
-import { Themes } from './service';
+import {
+	publishResponseSchema,
+	slugConflictSchema,
+	slugParamsSchema,
+	themeDraftSchema,
+	themeListSchema,
+	themeNotFoundSchema,
+	themeRecordSchema
+} from './model';
+import { getThemeBySlug, listThemes, publishTheme } from './service';
 
-export const themesController = new Elysia({ prefix: '/themes' });
-
-/* Create a theme and save to database. */
-themesController.post(
-	'/',
-	async ({ body }) => {
-		const res = await Themes.publish(body);
-		return res;
-	},
-	{
-		body: ThemesModel.publishBody,
+export const themesController = new Elysia({
+	prefix: '/themes',
+	tags: ['themes']
+})
+	.get('/', () => listThemes(), {
+		detail: { summary: 'List every built-in and published theme.' },
+		response: { 200: themeListSchema }
+	})
+	.get('/:slug', ({ params }) => getThemeBySlug(params.slug), {
+		params: slugParamsSchema,
+		detail: { summary: 'Fetch a theme by its slug.' },
 		response: {
-			200: ThemesModel.publishResponse,
-			409: ThemesModel.slugTaken
+			200: themeRecordSchema,
+			404: themeNotFoundSchema
 		}
-	}
-);
-
-/* Fetch all themes. */
-themesController.get('/', async () => {
-	return await Themes.getAll();
-});
-
-/* Fetch theme by slug. */
-themesController.get(
-	'/:slug',
-	async ({ params }) => {
-		const res = await Themes.getBySlug(params);
-		return res;
-	},
-	{
-		params: ThemesModel.getBySlugBody,
+	})
+	.post('/', ({ body }) => publishTheme(body), {
+		body: themeDraftSchema,
+		detail: { summary: 'Publish a new theme to the registry.' },
 		response: {
-			200: ThemesModel.getBySlugResponse,
-			404: ThemesModel.doesntExist
+			200: publishResponseSchema,
+			409: slugConflictSchema
 		}
-	}
-);
+	});

--- a/registry/src/services/themes/model.ts
+++ b/registry/src/services/themes/model.ts
@@ -1,11 +1,12 @@
-import { t, type UnwrapSchema } from 'elysia';
+import { t, type Static } from 'elysia';
 
-const ThemePalette = t.Object({
+export const paletteSchema = t.Object({
 	background: t.String(),
 	border: t.String(),
 	borderStrong: t.String(),
 	input: t.String(),
 	primary: t.String(),
+	info: t.String(),
 	foregroundOpposite: t.String(),
 	foreground: t.String(),
 	muted: t.String(),
@@ -24,7 +25,7 @@ const ThemePalette = t.Object({
 	ring: t.String()
 });
 
-const ThemeMotion = t.Object({
+export const motionSchema = t.Object({
 	panelDuration: t.String(),
 	panelX: t.Number(),
 	panelBlur: t.Number(),
@@ -35,71 +36,65 @@ const ThemeMotion = t.Object({
 	overlayBlur: t.Number()
 });
 
-const ThemeDurationPresetSlug = t.Union([
+export const durationPresetSlugSchema = t.Union([
 	t.Literal('default'),
 	t.Literal('snappy'),
 	t.Literal('instant'),
 	t.Literal('smooth')
 ]);
 
-export const ThemesModel = {
-	publishBody: t.Object({
-		slug: t.String(),
-		name: t.String(),
-		description: t.String(),
-		publisher: t.Optional(t.String()),
-		fontSans: t.String(),
-		fontMono: t.String(),
-		fontHeader: t.String(),
-		radiusBase: t.String(),
-		radiusSm: t.String(),
-		radiusMd: t.String(),
-		radiusLg: t.String(),
-		radiusXl: t.String(),
-		primaryButtonOutline: t.Boolean(),
-		invertedPanels: t.Boolean(),
-		durationPreset: ThemeDurationPresetSlug,
-		motion: ThemeMotion,
-		light: ThemePalette,
-		dark: ThemePalette
-	}),
-	publishResponse: t.Object({
-		success: t.Boolean(),
-		message: t.Literal('Successfully published theme!')
-	}),
-
-	getBySlugBody: t.Object({
-		slug: t.String()
-	}),
-
-	getBySlugResponse: t.Object({
-		id: t.String(),
-		slug: t.String(),
-		name: t.String(),
-		description: t.String(),
-		publisher: t.Optional(t.String()),
-		fontSans: t.String(),
-		fontMono: t.String(),
-		fontHeader: t.String(),
-		radiusBase: t.String(),
-		radiusSm: t.String(),
-		radiusMd: t.String(),
-		radiusLg: t.String(),
-		radiusXl: t.String(),
-		primaryButtonOutline: t.Boolean(),
-		invertedPanels: t.Boolean(),
-		durationPreset: ThemeDurationPresetSlug,
-		motion: ThemeMotion,
-		light: ThemePalette,
-		dark: ThemePalette,
-		createdAt: t.String(),
-		updatedAt: t.String()
-	}),
-
-	slugTaken: t.Literal('A theme with this slug already exists, try another one.'),
-	doesntExist: t.Literal('A theme with this slug does not exist.')
+const themeSharedFields = {
+	name: t.String({ minLength: 1 }),
+	description: t.String(),
+	publisher: t.Optional(t.String()),
+	fontSans: t.String(),
+	fontMono: t.String(),
+	fontHeader: t.String(),
+	radiusBase: t.String(),
+	radiusSm: t.String(),
+	radiusMd: t.String(),
+	radiusLg: t.String(),
+	radiusXl: t.String(),
+	primaryButtonOutline: t.Boolean(),
+	invertedPanels: t.Boolean(),
+	durationPreset: durationPresetSlugSchema,
+	motion: motionSchema,
+	light: paletteSchema,
+	dark: paletteSchema
 };
 
-export type ThemesModel = {
-	[k in keyof typeof ThemesModel]: UnwrapSchema<(typeof ThemesModel)[k]>;
-};
+export const themeDraftSchema = t.Object({
+	slug: t.String({ minLength: 1, pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$' }),
+	...themeSharedFields
+});
+
+export const themeRecordSchema = t.Object({
+	id: t.String(),
+	slug: t.String(),
+	...themeSharedFields,
+	createdAt: t.String(),
+	updatedAt: t.String()
+});
+
+export const themeListSchema = t.Array(themeRecordSchema);
+
+export const slugParamsSchema = t.Object({
+	slug: t.String({ minLength: 1 })
+});
+
+export const publishResponseSchema = t.Object({
+	success: t.Literal(true),
+	message: t.Literal('Successfully published theme!')
+});
+
+export const slugConflictSchema = t.Union([
+	t.Literal('A theme with this slug already exists, try another one.'),
+	t.Literal('This slug is reserved for a built-in theme.')
+]);
+export const themeNotFoundSchema = t.Literal('A theme with this slug does not exist.');
+
+export type ThemePalette = Static<typeof paletteSchema>;
+export type ThemeMotion = Static<typeof motionSchema>;
+export type ThemeDurationPresetSlug = Static<typeof durationPresetSlugSchema>;
+export type ThemeDraft = Static<typeof themeDraftSchema>;
+export type ThemeRecord = Static<typeof themeRecordSchema>;

--- a/registry/src/services/themes/service.ts
+++ b/registry/src/services/themes/service.ts
@@ -1,97 +1,82 @@
 import { status } from 'elysia';
 import { prisma } from '@lib/prisma';
-import type { ThemesModel } from './model';
-import { defaultThemes } from './defaults';
+import type { ThemeDraft, ThemeMotion, ThemePalette, ThemeRecord } from './model';
+import { defaultThemeRecord, defaultThemes, findDefaultTheme, isDefaultSlug } from './defaults';
 
-const DEFAULT_THEME_IDS = new Map(defaultThemes.map((theme) => [theme.slug, `default:${theme.slug}`]));
-const DEFAULT_THEME_CREATED_AT = '2026-04-04T00:00:00.000Z';
+type PersistedTheme = Awaited<ReturnType<typeof prisma.theme.findFirst>>;
 
-function toDefaultThemeRecord(theme: ThemesModel['publishBody']) {
-	return {
-		id: DEFAULT_THEME_IDS.get(theme.slug) ?? `default:${theme.slug}`,
-		...theme,
-		createdAt: DEFAULT_THEME_CREATED_AT,
-		updatedAt: DEFAULT_THEME_CREATED_AT
-	};
+const FALLBACK_INFO_LIGHT = '#2563eb';
+const FALLBACK_INFO_DARK = '#60a5fa';
+
+function toIso(value: Date | string): string {
+	return value instanceof Date ? value.toISOString() : value;
 }
 
-export abstract class Themes {
-	static async getAll() {
-		const themes = await prisma.theme.findMany({
-			orderBy: {
-				name: 'asc'
-			}
-		});
+function normalizePalette(palette: unknown, fallbackInfo: string): ThemePalette {
+	const value = palette as ThemePalette & { info?: string };
+	return value.info ? value : { ...value, info: fallbackInfo };
+}
 
-		const publishedThemeSlugs = new Set(themes.map((theme) => theme.slug));
-		const attachedDefaults = defaultThemes
-			.filter((theme) => !publishedThemeSlugs.has(theme.slug))
-			.map(toDefaultThemeRecord);
+function serialize(theme: NonNullable<PersistedTheme>): ThemeRecord {
+	const { publisher, motion, light, dark, createdAt, updatedAt, ...rest } = theme;
+	const record: ThemeRecord = {
+		...rest,
+		motion: motion as ThemeMotion,
+		light: normalizePalette(light, FALLBACK_INFO_LIGHT),
+		dark: normalizePalette(dark, FALLBACK_INFO_DARK),
+		createdAt: toIso(createdAt),
+		updatedAt: toIso(updatedAt)
+	};
+	if (publisher) record.publisher = publisher;
+	return record;
+}
 
-		return [...attachedDefaults, ...themes].sort((a, b) => a.name.localeCompare(b.name));
+export async function listThemes(): Promise<ThemeRecord[]> {
+	const rows = await prisma.theme.findMany({ orderBy: { name: 'asc' } });
+	const published = rows.map(serialize);
+	const publishedSlugs = new Set(published.map((theme) => theme.slug));
+
+	const unshadowedDefaults = defaultThemes
+		.filter((theme) => !publishedSlugs.has(theme.slug))
+		.map(defaultThemeRecord);
+
+	return [...unshadowedDefaults, ...published].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getThemeBySlug(slug: string): Promise<ThemeRecord> {
+	const builtIn = findDefaultTheme(slug);
+	if (builtIn) return defaultThemeRecord(builtIn);
+
+	const theme = await prisma.theme.findUnique({ where: { slug } });
+	if (!theme) {
+		throw status(404, 'A theme with this slug does not exist.' as const);
 	}
 
-	static async getBySlug(body: ThemesModel['getBySlugBody']) {
-		const defaultTheme = defaultThemes.find((theme) => theme.slug === body.slug);
-		if (defaultTheme) {
-			return toDefaultThemeRecord(defaultTheme);
+	return serialize(theme);
+}
+
+export async function publishTheme(input: ThemeDraft) {
+	if (isDefaultSlug(input.slug)) {
+		throw status(409, 'This slug is reserved for a built-in theme.' as const);
+	}
+
+	const existing = await prisma.theme.findUnique({
+		where: { slug: input.slug },
+		select: { id: true }
+	});
+	if (existing) {
+		throw status(409, 'A theme with this slug already exists, try another one.' as const);
+	}
+
+	await prisma.theme.create({
+		data: {
+			...input,
+			publisher: input.publisher ?? null
 		}
+	});
 
-		const theme = await prisma.theme.findUnique({
-			where: { slug: body.slug }
-		});
-
-		if (!theme)
-			throw status(
-				404,
-				'A theme with this slug does not exist.' satisfies ThemesModel['doesntExist']
-			);
-
-		return theme;
-	}
-
-	static async publish(body: ThemesModel['publishBody']) {
-		const existingTheme = await prisma.theme.findUnique({
-			where: {
-				slug: body.slug
-			},
-			select: {
-				id: true
-			}
-		});
-
-		if (existingTheme)
-			throw status(
-				409,
-				'A theme with this slug already exists, try another one.' satisfies ThemesModel['slugTaken']
-			);
-
-		await prisma.theme.create({
-			data: {
-				slug: body.slug,
-				name: body.name,
-				description: body.description,
-				publisher: body.publisher,
-				fontSans: body.fontSans,
-				fontMono: body.fontMono,
-				fontHeader: body.fontHeader,
-				radiusBase: body.radiusBase,
-				radiusSm: body.radiusSm,
-				radiusMd: body.radiusMd,
-				radiusLg: body.radiusLg,
-				radiusXl: body.radiusXl,
-				primaryButtonOutline: body.primaryButtonOutline,
-				invertedPanels: body.invertedPanels,
-				durationPreset: body.durationPreset,
-				motion: body.motion,
-				light: body.light,
-				dark: body.dark
-			}
-		});
-
-		return {
-			success: true,
-			message: 'Successfully published theme!' as const
-		};
-	}
+	return {
+		success: true as const,
+		message: 'Successfully published theme!' as const
+	};
 }


### PR DESCRIPTION
## Summary

Rewrite of `registry/src/services/themes/` focused on correctness and type parity with the app consumer.

- **`model.ts`** — share one field set between `ThemeDraft` and `ThemeRecord` so they cannot drift. Add the missing `info` palette field that `$lib/silk/themes/presets` already requires, tighten the `slug` pattern, and collapse the two slug-error literals into a single 409 union.
- **`defaults.ts`** — add `info` to every built-in light/dark palette and export `isDefaultSlug` / `findDefaultTheme` / `defaultThemeRecord` helpers.
- **`service.ts`** — replace the abstract class with pure functions. New `serialize` converts prisma `Date` to ISO strings, normalizes `null` publisher to `undefined`, and backfills `info` for legacy rows so response validation does not reject pre-rewrite data. `publishTheme` now reserves built-in slugs and spreads the validated input instead of hand-mapping every column.
- **`index.ts`** — terser controller with OpenAPI `tags` / `summary` metadata and typed response maps for every status code.

## Why

- Studio-published themes include `info` in their palette, but the old registry schema did not — validation would drop or reject the field. Round-trip is now lossless.
- Prisma returns `Date` objects and `null` for optional columns, but the old response schema declared them as `string` / `Optional(string)`, so the old schema and the real payload disagreed.
- Nothing previously prevented a user from publishing `default`, `graphite`, etc., silently shadowing the built-ins.

## Test plan

- [x] `bunx tsc --noEmit` passes (only pre-existing tsconfig deprecation warnings).
- [x] `bun build src/index.ts --target bun` succeeds.
- [ ] Manual: `GET /themes`, `GET /themes/default`, and `POST /themes` against a running instance.
- [ ] Manual: verify publishing from the Theme Studio succeeds and the `info` token round-trips into the generated CSS.

https://claude.ai/code/session_012ESRU7FW3eJu24jFR37p7c

---
_Generated by [Claude Code](https://claude.ai/code/session_012ESRU7FW3eJu24jFR37p7c)_