### PR TITLE
feat(cli): add @silk-ui/cli package (silk init / add / add theme / list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules
 .wrangler
 /.svelte-kit
 /build
+packages/cli/dist
+packages/cli/registry
 
 # OS
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,6 @@ node_modules
 **/build
 **/dist
 **/generated
+packages/cli/registry
 bun.lock
 *.svx

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ silk/
 │   ├── docs/        # SvelteKit docs site + theme studio
 │   └── registry/    # Elysia + Prisma API serving themes from Supabase
 ├── packages/
+│   ├── cli/         # @silk-ui/cli — installs components into consumer projects (silk init/add/list)
 │   └── silk/        # Canonical component source (consumed by apps/docs via the @silk/ui alias)
 ├── docker-compose.yml
 ├── turbo.json

--- a/bun.lock
+++ b/bun.lock
@@ -79,6 +79,20 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/cli": {
+      "name": "@silk-ui/cli",
+      "version": "0.1.0",
+      "bin": {
+        "silk": "./dist/index.js",
+      },
+      "devDependencies": {
+        "@clack/prompts": "^0.11.0",
+        "bun-types": "latest",
+        "commander": "^14.0.2",
+        "picocolors": "^1.1.1",
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/silk": {
       "name": "@silk/ui",
       "version": "0.0.0",
@@ -124,6 +138,10 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -359,6 +377,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@silk-ui/cli": ["@silk-ui/cli@workspace:packages/cli"],
+
     "@silk/ui": ["@silk/ui@workspace:packages/silk"],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
@@ -548,6 +568,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
@@ -1018,6 +1040,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/packages/cli/.prettierignore
+++ b/packages/cli/.prettierignore
@@ -1,0 +1,2 @@
+dist
+registry

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,98 @@
+# @silk-ui/cli
+
+Install [Silk UI](https://silk-ui.dev) components into your Svelte project. Like shadcn:
+the CLI copies component source into your repo — you own the code, there is no runtime
+library dependency.
+
+```bash
+npx @silk-ui/cli init
+npx @silk-ui/cli add button
+```
+
+## Commands
+
+### `silk init`
+
+Bootstraps silk in the current project:
+
+- writes `silk.json` (install directory, import alias, theme registry URL)
+- installs the theme tokens (`ui.css`), `utils.ts`, and `internals/*`
+- reports any missing peer dependencies
+
+```bash
+silk init          # interactive prompts
+silk init --yes    # accept defaults (src/lib/silk, $lib/silk)
+```
+
+Import the installed `ui.css` in your root layout or app stylesheet to activate the
+token system.
+
+### `silk add <component...>`
+
+Installs one or more components plus their transitive dependencies. Imports are
+rewritten from `@silk/ui` to the alias configured in `silk.json`, installed versions
+are recorded in `silk.json`, and missing npm peer dependencies are detected (and
+installed for you if you confirm, or automatically with `--yes`).
+
+```bash
+silk add command            # pulls popover and button too
+silk add dialog sheet -y    # multiple at once, no prompts
+silk add button --overwrite # replace files that already exist
+```
+
+Existing files are never touched unless you pass `--overwrite`.
+
+### `silk add theme <slug>`
+
+Installs a theme as `theme.css` next to `ui.css`. Built-in presets resolve offline;
+anything else is fetched from the theme registry (`registry` in `silk.json`) and
+rendered to CSS. Import it after `ui.css` so its tokens win.
+
+```bash
+silk add theme default
+```
+
+Browse community themes at [silk-ui.dev/themes](https://silk-ui.dev/themes).
+
+### `silk list`
+
+Prints every installable component (name, version, description) and the built-in
+themes.
+
+## `silk.json`
+
+```json
+{
+	"dir": "src/lib/silk",
+	"alias": "$lib/silk",
+	"registry": "https://silk-ui.dev/api",
+	"components": {
+		"button": "3.0.0"
+	}
+}
+```
+
+| Field        | Purpose                                                  |
+| ------------ | -------------------------------------------------------- |
+| `dir`        | Directory component source is copied into                |
+| `alias`      | Import alias that replaces `@silk/ui` in installed files |
+| `registry`   | Theme registry API base URL used by `silk add theme`     |
+| `components` | Installed components and versions, maintained by the CLI |
+
+## How it works
+
+Every component in `packages/silk` declares a `manifest.ts` (files, transitive
+component deps, shared utilities, npm peers). `bun run build:registry` snapshots all
+manifests into `registry/index.json` and copies the referenced sources into
+`registry/files/`. That snapshot ships inside the npm package, so `silk add` resolves
+and installs entirely offline — only `silk add theme <slug>` for non-built-in slugs
+goes to the network.
+
+## Development
+
+```bash
+bun run build:registry   # rebuild the registry snapshot from packages/silk
+bun run build            # snapshot + bundle dist/index.js
+bun run test             # bun test (resolver, rewriting, snapshot integrity)
+bun run check            # tsc --noEmit
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@silk-ui/cli",
+	"version": "0.1.0",
+	"description": "Install Silk UI components into your Svelte project. Owns-the-code distribution, shadcn style.",
+	"type": "module",
+	"license": "MIT",
+	"bin": {
+		"silk": "./dist/index.js"
+	},
+	"files": [
+		"dist",
+		"registry"
+	],
+	"engines": {
+		"node": ">=20"
+	},
+	"scripts": {
+		"build:registry": "bun scripts/build-registry.ts",
+		"build": "bun run build:registry && bun build src/index.ts --outdir dist --target node --banner '#!/usr/bin/env node'",
+		"check": "tsc --noEmit",
+		"test": "bun run build:registry && bun test",
+		"lint": "prettier --check ."
+	},
+	"devDependencies": {
+		"@clack/prompts": "^0.11.0",
+		"bun-types": "latest",
+		"commander": "^14.0.2",
+		"picocolors": "^1.1.1",
+		"typescript": "^5.9.3"
+	}
+}

--- a/packages/cli/scripts/build-registry.ts
+++ b/packages/cli/scripts/build-registry.ts
@@ -1,0 +1,135 @@
+/**
+ * Snapshots the silk component registry into `registry/`.
+ *
+ * Run with bun from packages/cli (`bun run build:registry`). Imports every
+ * `manifest.ts` under packages/silk/src/components, validates that the
+ * files each manifest references exist, then writes:
+ *
+ *   registry/index.json   -- RegistryIndex consumed by the CLI at runtime
+ *   registry/files/**     -- raw component/shared sources, paths preserved
+ *   registry/themes.json  -- built-in theme presets pre-rendered to CSS
+ */
+
+import { mkdir, readdir, rm, copyFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { themeToCss } from '../../silk/src/themes/presets';
+import type { ThemeDraft } from '../../silk/src/themes/presets';
+import type { Manifest } from '../../silk/src/_manifest/types';
+import type { RegistryIndex, RegistryTheme } from '../src/types';
+import pkg from '../package.json';
+
+const cliRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const silkSrc = path.resolve(cliRoot, '../silk/src');
+const outDir = path.join(cliRoot, 'registry');
+
+async function collectManifestPaths() {
+	const componentsDir = path.join(silkSrc, 'components');
+	const result: string[] = [];
+	for (const entry of await readdir(componentsDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		if (entry.name === '_internal') {
+			for (const inner of await readdir(path.join(componentsDir, entry.name), {
+				withFileTypes: true
+			})) {
+				if (!inner.isDirectory()) continue;
+				const manifest = path.join(componentsDir, entry.name, inner.name, 'manifest.ts');
+				if (existsSync(manifest)) result.push(manifest);
+			}
+			continue;
+		}
+		const manifest = path.join(componentsDir, entry.name, 'manifest.ts');
+		if (existsSync(manifest)) result.push(manifest);
+	}
+	return result.sort();
+}
+
+/** Resolves a manifest `shared` entry to source files relative to silk src. */
+function sharedToFiles(entry: string): string[] {
+	if (entry.startsWith('utils.')) return ['utils.ts'];
+	if (entry.startsWith('internals/')) {
+		const module = entry.slice('internals/'.length);
+		for (const candidate of [`internals/${module}.ts`, `internals/${module}.svelte.ts`]) {
+			if (existsSync(path.join(silkSrc, candidate))) return [candidate];
+		}
+		throw new Error(`shared entry "${entry}" resolves to no file under ${silkSrc}/internals`);
+	}
+	throw new Error(`unrecognized shared entry "${entry}"`);
+}
+
+async function buildThemes(): Promise<RegistryTheme[]> {
+	const presetsDir = path.join(silkSrc, 'themes/presets');
+	const themes: RegistryTheme[] = [];
+	for (const file of (await readdir(presetsDir)).sort()) {
+		if (!file.endsWith('.ts')) continue;
+		const module = (await import(path.join(presetsDir, file))) as Record<string, ThemeDraft>;
+		const draft = module.preset ?? module.theme ?? module.defaultTheme;
+		if (!draft) continue;
+		themes.push({
+			slug: draft.slug,
+			name: draft.name,
+			description: draft.description,
+			css: themeToCss(draft)
+		});
+	}
+	return themes;
+}
+
+const manifests: Manifest[] = [];
+for (const manifestPath of await collectManifestPaths()) {
+	const module = (await import(manifestPath)) as { manifest: Manifest };
+	if (!module.manifest?.name) throw new Error(`${manifestPath} exports no manifest`);
+	manifests.push(module.manifest);
+}
+
+const fileSet = new Set<string>(['ui.css']);
+const known = new Set(manifests.map((m) => m.name));
+for (const manifest of manifests) {
+	for (const dep of manifest.components) {
+		if (!known.has(dep)) {
+			throw new Error(`${manifest.name} depends on unknown component "${dep}"`);
+		}
+	}
+	for (const file of manifest.files) fileSet.add(file);
+	for (const entry of manifest.shared) sharedToFiles(entry).forEach((f) => fileSet.add(f));
+}
+
+for (const file of fileSet) {
+	if (!existsSync(path.join(silkSrc, file))) {
+		throw new Error(`registry references missing file: ${file}`);
+	}
+}
+
+await rm(outDir, { recursive: true, force: true });
+for (const file of fileSet) {
+	const target = path.join(outDir, 'files', file);
+	await mkdir(path.dirname(target), { recursive: true });
+	await copyFile(path.join(silkSrc, file), target);
+}
+
+const index: RegistryIndex = {
+	cliVersion: pkg.version,
+	builtAt: new Date().toISOString(),
+	components: manifests.map(
+		({ name, version, visibility, description, files, components, shared, peerDependencies }) => ({
+			name,
+			version,
+			visibility,
+			description,
+			files,
+			components,
+			shared,
+			sharedFiles: [...new Set(shared.flatMap(sharedToFiles))],
+			peerDependencies
+		})
+	)
+};
+
+await writeFile(path.join(outDir, 'index.json'), JSON.stringify(index, null, '\t') + '\n');
+await writeFile(
+	path.join(outDir, 'themes.json'),
+	JSON.stringify(await buildThemes(), null, '\t') + '\n'
+);
+
+console.log(`registry: ${index.components.length} components, ${fileSet.size} files, themes built`);

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,111 @@
+import * as clack from '@clack/prompts';
+import { spawnSync } from 'node:child_process';
+import pc from 'picocolors';
+import { CONFIG_FILE, loadConfig, saveConfig } from '../config';
+import { ResolveError, installableFiles, loadRegistryIndex, resolveInstallPlan } from '../registry';
+import {
+	type CopyResult,
+	declaredDependencies,
+	detectPackageManager,
+	installCommand,
+	installFile
+} from '../utils/project';
+import { fail, ok, tree, warn } from '../utils/ui';
+
+export type AddOptions = {
+	cwd: string;
+	yes: boolean;
+	overwrite: boolean;
+};
+
+const RESULT_MARK: Record<CopyResult, string> = {
+	created: pc.green('+'),
+	overwritten: pc.yellow('~'),
+	skipped: pc.dim('=')
+};
+
+export async function add(names: string[], options: AddOptions) {
+	const { cwd, yes, overwrite } = options;
+
+	const config = await loadConfig(cwd);
+	if (!config) {
+		fail(`no ${CONFIG_FILE} found -- run ${pc.cyan('silk init')} first.`);
+		process.exitCode = 1;
+		return;
+	}
+
+	const index = await loadRegistryIndex();
+	let plan;
+	try {
+		plan = resolveInstallPlan(index, names);
+	} catch (error) {
+		if (error instanceof ResolveError) {
+			fail(error.message);
+			console.log(`  run ${pc.cyan('silk list')} to see what's available.`);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+
+	const pulled = plan.components.filter((c) => !names.includes(c.name));
+	clack.intro(pc.bgMagenta(pc.black(' silk add ')));
+	if (pulled.length > 0) {
+		console.log(
+			`${pc.dim('│')}  pulling ${pulled.map((c) => pc.cyan(c.name)).join(', ')} as dependencies`
+		);
+	}
+
+	const spinner = clack.spinner();
+	spinner.start(`Installing ${plan.components.length} component(s) into ${config.dir}`);
+
+	const summaries: { heading: string; lines: string[] }[] = [];
+	let skipped = 0;
+	for (const component of plan.components) {
+		const lines: string[] = [];
+		const files = [...installableFiles(component), ...component.sharedFiles];
+		for (const file of files) {
+			const result = await installFile(cwd, config.dir, file, config.alias, overwrite);
+			if (result === 'skipped') skipped++;
+			lines.push(`${RESULT_MARK[result]} ${file}`);
+		}
+		config.components[component.name] = component.version;
+		summaries.push({
+			heading: `${pc.bold(component.name)} ${pc.dim(`v${component.version}`)}`,
+			lines
+		});
+	}
+	await saveConfig(cwd, config);
+	spinner.stop(`Installed into ${pc.cyan(config.dir)}`);
+
+	for (const summary of summaries) tree(summary.heading, summary.lines);
+	if (skipped > 0) {
+		warn(`${skipped} file(s) already existed and were left alone -- pass --overwrite to replace.`);
+	}
+
+	const declared = await declaredDependencies(cwd);
+	const missing = Object.keys(plan.peerDependencies).filter((dep) => !declared.has(dep));
+	if (missing.length > 0) {
+		const pm = detectPackageManager(cwd);
+		const command = installCommand(pm, missing);
+		warn(`missing peer dependencies: ${missing.map((d) => pc.yellow(d)).join(', ')}`);
+
+		let install = yes;
+		if (!yes && process.stdout.isTTY) {
+			const answer = await clack.confirm({ message: `Run ${pc.cyan(command)} now?` });
+			install = answer === true;
+		}
+		if (install) {
+			const [bin, ...args] = command.split(' ');
+			const result = spawnSync(bin, args, { cwd, stdio: 'inherit' });
+			if (result.status === 0) ok('peer dependencies installed.');
+			else warn(`"${command}" exited with ${result.status} -- install them manually.`);
+		} else {
+			console.log(`  install with ${pc.cyan(command)}`);
+		}
+	}
+
+	clack.outro(
+		`Done -- ${plan.components.length} component(s) ready under ${pc.cyan(config.alias)}.`
+	);
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,94 @@
+import * as clack from '@clack/prompts';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import pc from 'picocolors';
+import { CONFIG_FILE, DEFAULT_CONFIG, loadConfig, saveConfig } from '../config';
+import { loadRegistryIndex } from '../registry';
+import {
+	declaredDependencies,
+	detectPackageManager,
+	installCommand,
+	installFile
+} from '../utils/project';
+import { ok, warn } from '../utils/ui';
+
+/** Peers required by the base install (utils.ts + theme tokens). */
+const BASE_PEERS = ['svelte', 'tailwindcss', 'clsx', 'tailwind-merge', '@floating-ui/dom'];
+
+export type InitOptions = {
+	cwd: string;
+	yes: boolean;
+};
+
+/** Shared files every silk project needs before any component lands. */
+export async function baseFiles() {
+	const index = await loadRegistryIndex();
+	const files = new Set<string>(['ui.css']);
+	for (const component of index.components) {
+		for (const file of component.sharedFiles) files.add(file);
+	}
+	return [...files].sort();
+}
+
+export async function init(options: InitOptions) {
+	const { cwd, yes } = options;
+
+	clack.intro(pc.bgMagenta(pc.black(' silk init ')));
+
+	if (await loadConfig(cwd)) {
+		clack.outro(`${CONFIG_FILE} already exists -- run ${pc.cyan('silk add <component>')} instead.`);
+		return;
+	}
+
+	const isSvelte = existsSync(path.join(cwd, 'svelte.config.js'));
+	if (!isSvelte) {
+		warn(`no svelte.config.js found in ${cwd} -- silk targets Svelte 5 + SvelteKit projects.`);
+	}
+
+	let dir = DEFAULT_CONFIG.dir;
+	let alias = DEFAULT_CONFIG.alias;
+	if (!yes) {
+		const dirAnswer = await clack.text({
+			message: 'Where should silk components live?',
+			defaultValue: DEFAULT_CONFIG.dir,
+			placeholder: DEFAULT_CONFIG.dir
+		});
+		if (clack.isCancel(dirAnswer)) {
+			clack.cancel('init cancelled.');
+			return;
+		}
+		dir = dirAnswer || DEFAULT_CONFIG.dir;
+
+		const aliasAnswer = await clack.text({
+			message: 'Import alias for that directory?',
+			defaultValue: DEFAULT_CONFIG.alias,
+			placeholder: DEFAULT_CONFIG.alias
+		});
+		if (clack.isCancel(aliasAnswer)) {
+			clack.cancel('init cancelled.');
+			return;
+		}
+		alias = aliasAnswer || DEFAULT_CONFIG.alias;
+	}
+
+	const config = { ...DEFAULT_CONFIG, dir, alias, components: {} };
+
+	const spinner = clack.spinner();
+	spinner.start('Installing theme tokens and shared utilities');
+	for (const file of await baseFiles()) {
+		await installFile(cwd, dir, file, alias, false);
+	}
+	await saveConfig(cwd, config);
+	spinner.stop(`Installed ${pc.cyan(`${dir}/ui.css`)}, utils, internals, and ${CONFIG_FILE}`);
+
+	const declared = await declaredDependencies(cwd);
+	const missing = BASE_PEERS.filter((dep) => !declared.has(dep));
+	if (missing.length > 0) {
+		const pm = detectPackageManager(cwd);
+		warn(`missing peer dependencies: ${missing.map((d) => pc.yellow(d)).join(', ')}`);
+		console.log(`  install with ${pc.cyan(installCommand(pm, missing))}`);
+	}
+
+	ok(`import ${pc.cyan(`${dir}/ui.css`)} in your root layout or app stylesheet.`);
+	clack.outro(`Ready -- run ${pc.cyan('silk add button')} to install your first component.`);
+}

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,0 +1,39 @@
+import pc from 'picocolors';
+import { loadRegistryIndex, loadRegistryThemes } from '../registry';
+
+function truncate(text: string, width: number) {
+	return text.length <= width ? text : `${text.slice(0, Math.max(width - 1, 0))}…`;
+}
+
+export async function list() {
+	const index = await loadRegistryIndex();
+	const components = index.components
+		.filter((component) => component.visibility === 'public')
+		.sort((a, b) => a.name.localeCompare(b.name));
+
+	const nameWidth = Math.max(...components.map((c) => c.name.length));
+	const descriptionWidth = Math.max((process.stdout.columns || 100) - nameWidth - 14, 20);
+
+	console.log();
+	console.log(`  ${pc.bold(`${components.length} components`)}`);
+	console.log();
+	for (const component of components) {
+		console.log(
+			`  ${pc.cyan(component.name.padEnd(nameWidth))}  ${pc.dim(`v${component.version}`.padEnd(7))} ${pc.dim(truncate(component.description ?? '', descriptionWidth))}`
+		);
+	}
+
+	const themes = await loadRegistryThemes();
+	if (themes.length > 0) {
+		console.log();
+		console.log(`  ${pc.bold(`${themes.length} built-in theme(s)`)}`);
+		console.log();
+		for (const theme of themes) {
+			console.log(`  ${pc.magenta(theme.slug.padEnd(nameWidth))}  ${pc.dim(theme.name)}`);
+		}
+	}
+
+	console.log();
+	console.log(`  ${pc.dim('install with')} ${pc.cyan('silk add <component>')}`);
+	console.log();
+}

--- a/packages/cli/src/commands/theme.ts
+++ b/packages/cli/src/commands/theme.ts
@@ -1,0 +1,68 @@
+import * as clack from '@clack/prompts';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import pc from 'picocolors';
+import { themeToCss, type ThemeDraft } from '../../../silk/src/themes/presets';
+import { CONFIG_FILE, loadConfig } from '../config';
+import { loadRegistryThemes } from '../registry';
+import { fail, ok } from '../utils/ui';
+
+export type ThemeOptions = {
+	cwd: string;
+};
+
+/** Resolves a slug to theme CSS -- built-in presets first, registry after. */
+async function resolveThemeCss(slug: string, registry: string) {
+	const builtin = (await loadRegistryThemes()).find((theme) => theme.slug === slug);
+	if (builtin) return { css: builtin.css, source: 'built-in preset' };
+
+	const url = `${registry.replace(/\/+$/, '')}/themes/${slug}`;
+	let response: Response;
+	try {
+		response = await fetch(url);
+	} catch {
+		throw new Error(`theme registry unreachable at ${url}`);
+	}
+	if (response.status === 404) {
+		throw new Error(`no theme "${slug}" in the registry -- browse https://silk-ui.dev/themes`);
+	}
+	if (!response.ok) {
+		throw new Error(`theme registry responded ${response.status} for ${url}`);
+	}
+	const draft = (await response.json()) as ThemeDraft;
+	return { css: themeToCss(draft), source: 'registry' };
+}
+
+export async function addTheme(slug: string, options: ThemeOptions) {
+	const { cwd } = options;
+
+	const config = await loadConfig(cwd);
+	if (!config) {
+		fail(`no ${CONFIG_FILE} found -- run ${pc.cyan('silk init')} first.`);
+		process.exitCode = 1;
+		return;
+	}
+
+	clack.intro(pc.bgMagenta(pc.black(' silk add theme ')));
+	const spinner = clack.spinner();
+	spinner.start(`Resolving theme ${pc.cyan(slug)}`);
+
+	let resolved;
+	try {
+		resolved = await resolveThemeCss(slug, config.registry);
+	} catch (error) {
+		spinner.stop('Theme resolution failed', 1);
+		fail(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+		return;
+	}
+
+	const target = path.join(cwd, config.dir, 'theme.css');
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, `/* silk theme: ${slug} */\n${resolved.css}\n`);
+	spinner.stop(`Fetched ${pc.cyan(slug)} (${resolved.source})`);
+
+	ok(`wrote ${pc.cyan(path.join(config.dir, 'theme.css'))}`);
+	console.log(`  import it ${pc.bold('after')} ${pc.cyan(`${config.dir}/ui.css`)} so it wins.`);
+	clack.outro('Theme installed.');
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,29 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import type { SilkConfig } from './types';
+
+export const CONFIG_FILE = 'silk.json';
+
+export const DEFAULT_CONFIG: SilkConfig = {
+	dir: 'src/lib/silk',
+	alias: '$lib/silk',
+	registry: 'https://silk-ui.dev/api',
+	components: {}
+};
+
+export function configPath(cwd: string) {
+	return path.join(cwd, CONFIG_FILE);
+}
+
+/** Reads silk.json from the project root, or null when not initialized. */
+export async function loadConfig(cwd: string): Promise<SilkConfig | null> {
+	const file = configPath(cwd);
+	if (!existsSync(file)) return null;
+	const parsed = JSON.parse(await readFile(file, 'utf8')) as Partial<SilkConfig>;
+	return { ...DEFAULT_CONFIG, ...parsed, components: parsed.components ?? {} };
+}
+
+export async function saveConfig(cwd: string, config: SilkConfig) {
+	await writeFile(configPath(cwd), JSON.stringify(config, null, '\t') + '\n');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,52 @@
+import { Command } from 'commander';
+import { add } from './commands/add';
+import { init } from './commands/init';
+import { list } from './commands/list';
+import { addTheme } from './commands/theme';
+import { banner } from './utils/ui';
+import pkg from '../package.json';
+
+const program = new Command('silk')
+	.description('Install Silk UI components into your Svelte project.')
+	.version(pkg.version)
+	.option('-C, --cwd <dir>', 'project root to operate in', process.cwd());
+
+program
+	.command('init')
+	.description('bootstrap silk.json, theme tokens, and shared utilities')
+	.option('-y, --yes', 'accept all defaults without prompting', false)
+	.action(async (options: { yes: boolean }) => {
+		banner(pkg.version);
+		await init({ cwd: program.opts().cwd, yes: options.yes });
+	});
+
+program
+	.command('add')
+	.description('add components (or `add theme <slug>`) to your project')
+	.argument('<names...>', 'component names, or `theme <slug>`')
+	.option('-y, --yes', 'skip prompts; auto-install missing peer dependencies', false)
+	.option('-o, --overwrite', 'replace files that already exist', false)
+	.action(async (names: string[], options: { yes: boolean; overwrite: boolean }) => {
+		const cwd = program.opts().cwd;
+		if (names[0] === 'theme') {
+			if (names.length !== 2) {
+				program.error('usage: silk add theme <slug>');
+			}
+			await addTheme(names[1], { cwd });
+			return;
+		}
+		await add(names, { cwd, yes: options.yes, overwrite: options.overwrite });
+	});
+
+program
+	.command('list')
+	.description('list every installable component and built-in theme')
+	.action(async () => {
+		banner(pkg.version);
+		await list();
+	});
+
+program.parseAsync().catch((error) => {
+	console.error(error instanceof Error ? error.message : error);
+	process.exit(1);
+});

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import {
+	ResolveError,
+	installableFiles,
+	loadRegistryIndex,
+	loadRegistryThemes,
+	registryFilePath,
+	resolveInstallPlan,
+	rewriteImports,
+	suggestComponent
+} from './registry';
+import type { RegistryComponent, RegistryIndex } from './types';
+
+function component(overrides: Partial<RegistryComponent>): RegistryComponent {
+	return {
+		name: 'button',
+		version: '1.0.0',
+		visibility: 'public',
+		files: [],
+		components: [],
+		shared: [],
+		sharedFiles: [],
+		peerDependencies: {},
+		...overrides
+	};
+}
+
+function index(components: RegistryComponent[]): RegistryIndex {
+	return { cliVersion: '0.0.0', builtAt: 'test', components };
+}
+
+describe('resolveInstallPlan', () => {
+	const fixture = index([
+		component({ name: 'button', peerDependencies: { svelte: '^5.0.0', clsx: '^2.0.0' } }),
+		component({ name: 'popover', components: ['button'] }),
+		component({
+			name: 'command',
+			components: ['popover', 'button'],
+			peerDependencies: { 'fuse.js': '^7.0.0' }
+		}),
+		component({ name: '_internal/overlay', visibility: 'internal' }),
+		component({ name: 'modal', components: ['button', '_internal/overlay'] })
+	]);
+
+	test('resolves transitive dependencies once', () => {
+		const plan = resolveInstallPlan(fixture, ['command']);
+		expect(plan.components.map((c) => c.name)).toEqual(['command', 'popover', 'button']);
+	});
+
+	test('pulls internal components as dependencies', () => {
+		const plan = resolveInstallPlan(fixture, ['modal']);
+		expect(plan.components.map((c) => c.name)).toContain('_internal/overlay');
+	});
+
+	test('rejects internal components as direct targets', () => {
+		expect(() => resolveInstallPlan(fixture, ['_internal/overlay'])).toThrow(ResolveError);
+	});
+
+	test('rejects unknown components with a suggestion', () => {
+		expect(() => resolveInstallPlan(fixture, ['bttn'])).toThrow('did you mean "button"');
+	});
+
+	test('unions peer dependencies across the plan', () => {
+		const plan = resolveInstallPlan(fixture, ['command']);
+		expect(Object.keys(plan.peerDependencies).sort()).toEqual(['clsx', 'fuse.js', 'svelte']);
+	});
+});
+
+describe('suggestComponent', () => {
+	const fixture = index([
+		component({ name: 'button' }),
+		component({ name: '_internal/overlay', visibility: 'internal' })
+	]);
+
+	test('never suggests internal components', () => {
+		expect(suggestComponent(fixture, 'overlay')).toBeNull();
+	});
+
+	test('suggests close public names', () => {
+		expect(suggestComponent(fixture, 'buton')).toBe('button');
+	});
+});
+
+describe('installableFiles', () => {
+	test('excludes manifest.ts', () => {
+		const files = installableFiles(
+			component({
+				files: ['components/button/button.svelte', 'components/button/manifest.ts']
+			})
+		);
+		expect(files).toEqual(['components/button/button.svelte']);
+	});
+});
+
+describe('rewriteImports', () => {
+	test('rewrites subpath and bare imports', () => {
+		const source = [
+			"import { cn } from '@silk/ui/utils';",
+			"import { states } from '@silk/ui/internals/state.svelte.ts';",
+			"import Button from '@silk/ui';"
+		].join('\n');
+		expect(rewriteImports(source, '$lib/silk')).toBe(
+			[
+				"import { cn } from '$lib/silk/utils';",
+				"import { states } from '$lib/silk/internals/state.svelte.ts';",
+				"import Button from '$lib/silk';"
+			].join('\n')
+		);
+	});
+
+	test('leaves unrelated imports alone', () => {
+		const source = "import Search from '@lucide/svelte/icons/search';";
+		expect(rewriteImports(source, '$lib/silk')).toBe(source);
+	});
+});
+
+describe('registry snapshot', () => {
+	test('index loads and every referenced file exists', async () => {
+		const snapshot = await loadRegistryIndex();
+		expect(snapshot.components.length).toBeGreaterThan(30);
+		for (const entry of snapshot.components) {
+			for (const file of [...installableFiles(entry), ...entry.sharedFiles]) {
+				expect(existsSync(registryFilePath(file))).toBe(true);
+			}
+		}
+	});
+
+	test('every dependency resolves against the index', async () => {
+		const snapshot = await loadRegistryIndex();
+		const publicNames = snapshot.components
+			.filter((c) => c.visibility === 'public')
+			.map((c) => c.name);
+		const plan = resolveInstallPlan(snapshot, publicNames);
+		expect(plan.components.length).toBe(snapshot.components.length);
+	});
+
+	test('built-in themes carry rendered css', async () => {
+		const themes = await loadRegistryThemes();
+		expect(themes.length).toBeGreaterThan(0);
+		for (const theme of themes) {
+			expect(theme.css).toContain('@theme {');
+			expect(theme.css).toContain('.dark {');
+		}
+	});
+});

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,118 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RegistryComponent, RegistryIndex, RegistryTheme } from './types';
+
+/**
+ * The registry snapshot lives at the package root (next to dist/), so it
+ * resolves from both src (bun test) and the bundled dist entry.
+ */
+const registryDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../registry');
+
+export async function loadRegistryIndex(): Promise<RegistryIndex> {
+	return JSON.parse(await readFile(path.join(registryDir, 'index.json'), 'utf8'));
+}
+
+export async function loadRegistryThemes(): Promise<RegistryTheme[]> {
+	return JSON.parse(await readFile(path.join(registryDir, 'themes.json'), 'utf8'));
+}
+
+export function registryFilePath(file: string) {
+	return path.join(registryDir, 'files', file);
+}
+
+export type InstallPlan = {
+	/** Requested components plus transitive dependencies, install order. */
+	components: RegistryComponent[];
+	/** Union of npm peer dependencies across the plan. */
+	peerDependencies: Record<string, string>;
+};
+
+/** Files `silk add` copies for one component. Manifests are registry
+ * metadata, not consumer code -- versions are tracked in silk.json. */
+export function installableFiles(component: RegistryComponent) {
+	return component.files.filter((file) => path.basename(file) !== 'manifest.ts');
+}
+
+function levenshtein(a: string, b: string) {
+	const rows = Array.from({ length: a.length + 1 }, (_, i) => {
+		const row = new Array<number>(b.length + 1).fill(0);
+		row[0] = i;
+		return row;
+	});
+	for (let j = 0; j <= b.length; j++) rows[0][j] = j;
+	for (let i = 1; i <= a.length; i++) {
+		for (let j = 1; j <= b.length; j++) {
+			rows[i][j] = Math.min(
+				rows[i - 1][j] + 1,
+				rows[i][j - 1] + 1,
+				rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+			);
+		}
+	}
+	return rows[a.length][b.length];
+}
+
+/** Closest public component name, used for typo hints. */
+export function suggestComponent(index: RegistryIndex, input: string) {
+	const candidates = index.components.filter((c) => c.visibility === 'public');
+	let best: { name: string; distance: number } | null = null;
+	for (const candidate of candidates) {
+		const distance = levenshtein(input, candidate.name);
+		if (!best || distance < best.distance) best = { name: candidate.name, distance };
+	}
+	return best && best.distance <= 3 ? best.name : null;
+}
+
+export class ResolveError extends Error {}
+
+/**
+ * Resolves requested component names into a full install plan, walking
+ * transitive `components` dependencies. Requested names must be public;
+ * internal components are reachable only as dependencies.
+ */
+export function resolveInstallPlan(index: RegistryIndex, names: string[]): InstallPlan {
+	const byName = new Map(index.components.map((c) => [c.name, c]));
+
+	for (const name of names) {
+		const component = byName.get(name);
+		if (!component) {
+			const suggestion = suggestComponent(index, name);
+			throw new ResolveError(
+				`unknown component "${name}"${suggestion ? ` -- did you mean "${suggestion}"?` : ''}`
+			);
+		}
+		if (component.visibility !== 'public') {
+			throw new ResolveError(
+				`"${name}" is internal and installs only as a dependency of other components`
+			);
+		}
+	}
+
+	const resolved = new Map<string, RegistryComponent>();
+	const queue = [...names];
+	while (queue.length > 0) {
+		const name = queue.shift()!;
+		if (resolved.has(name)) continue;
+		const component = byName.get(name);
+		if (!component) {
+			throw new ResolveError(`registry index is missing dependency "${name}"`);
+		}
+		resolved.set(name, component);
+		queue.push(...component.components);
+	}
+
+	const peerDependencies: Record<string, string> = {};
+	for (const component of resolved.values()) {
+		for (const [dep, range] of Object.entries(component.peerDependencies)) {
+			peerDependencies[dep] ??= range;
+		}
+	}
+
+	return { components: [...resolved.values()], peerDependencies };
+}
+
+/** Rewrites `@silk/ui/...` imports to the consumer's configured alias. */
+export function rewriteImports(source: string, alias: string) {
+	return source.replaceAll(/@silk\/ui(?=['/])/g, alias);
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Registry artifact types.
+ *
+ * `scripts/build-registry.ts` snapshots every component manifest from
+ * `packages/silk` into `registry/index.json` (this shape) plus the raw
+ * source files under `registry/files/`. The published CLI ships that
+ * snapshot so `silk add` works without a server.
+ */
+
+export type RegistryComponent = {
+	name: string;
+	version: string;
+	visibility: 'public' | 'internal';
+	description?: string;
+	/** Paths relative to the silk source root (e.g. `components/button/button.svelte`). */
+	files: string[];
+	/** Other silk components this one pulls in transitively. */
+	components: string[];
+	/** `utils.<symbol>` or `internals/<module>` shared dependencies. */
+	shared: string[];
+	/** `shared` entries resolved to source files at snapshot time. */
+	sharedFiles: string[];
+	/** npm packages the consumer project must have installed. */
+	peerDependencies: Record<string, string>;
+};
+
+export type RegistryIndex = {
+	/** Version of the @silk-ui/cli package the snapshot was built with. */
+	cliVersion: string;
+	builtAt: string;
+	components: RegistryComponent[];
+};
+
+export type RegistryTheme = {
+	slug: string;
+	name: string;
+	description?: string;
+	css: string;
+};
+
+/** Shape of `silk.json` in the consumer project root. */
+export type SilkConfig = {
+	$schema?: string;
+	/** Directory silk source is installed into, relative to project root. */
+	dir: string;
+	/** Import alias that replaces `@silk/ui` in installed files. */
+	alias: string;
+	/** Theme registry API base URL used by `silk add theme <slug>`. */
+	registry: string;
+	/** Installed components and their versions, maintained by `silk add`. */
+	components: Record<string, string>;
+};

--- a/packages/cli/src/utils/project.ts
+++ b/packages/cli/src/utils/project.ts
@@ -1,0 +1,54 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { registryFilePath, rewriteImports } from '../registry';
+
+export type PackageManager = 'bun' | 'pnpm' | 'yarn' | 'npm';
+
+export function detectPackageManager(cwd: string): PackageManager {
+	if (existsSync(path.join(cwd, 'bun.lock')) || existsSync(path.join(cwd, 'bun.lockb')))
+		return 'bun';
+	if (existsSync(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+	if (existsSync(path.join(cwd, 'yarn.lock'))) return 'yarn';
+	return 'npm';
+}
+
+export function installCommand(pm: PackageManager, packages: string[]) {
+	const verb = pm === 'npm' ? 'install' : 'add';
+	return `${pm} ${verb} ${packages.join(' ')}`;
+}
+
+/** Dependencies declared anywhere in the consumer's package.json. */
+export async function declaredDependencies(cwd: string): Promise<Set<string>> {
+	const file = path.join(cwd, 'package.json');
+	if (!existsSync(file)) return new Set();
+	const pkg = JSON.parse(await readFile(file, 'utf8'));
+	return new Set([
+		...Object.keys(pkg.dependencies ?? {}),
+		...Object.keys(pkg.devDependencies ?? {}),
+		...Object.keys(pkg.peerDependencies ?? {})
+	]);
+}
+
+export type CopyResult = 'created' | 'overwritten' | 'skipped';
+
+/**
+ * Copies one registry file into the consumer project, rewriting
+ * `@silk/ui` imports to the configured alias. Existing files are left
+ * alone unless `overwrite` is set.
+ */
+export async function installFile(
+	cwd: string,
+	dir: string,
+	file: string,
+	alias: string,
+	overwrite: boolean
+): Promise<CopyResult> {
+	const target = path.join(cwd, dir, file);
+	const exists = existsSync(target);
+	if (exists && !overwrite) return 'skipped';
+	const source = await readFile(registryFilePath(file), 'utf8');
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, rewriteImports(source, alias));
+	return exists ? 'overwritten' : 'created';
+}

--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -1,0 +1,57 @@
+import pc from 'picocolors';
+
+/** Silk brand ramp -- primary indigo into the docs-site teal. */
+const GRADIENT_FROM: [number, number, number] = [94, 106, 210]; // #5e6ad2
+const GRADIENT_TO: [number, number, number] = [45, 212, 191]; // #2dd4bf
+
+function lerp(from: number, to: number, t: number) {
+	return Math.round(from + (to - from) * t);
+}
+
+/** Colors a single line with a horizontal truecolor gradient. */
+export function gradientLine(line: string) {
+	if (!pc.isColorSupported) return line;
+	const chars = [...line];
+	const last = Math.max(chars.length - 1, 1);
+	return chars
+		.map((char, i) => {
+			if (char.trim() === '') return char;
+			const t = i / last;
+			const r = lerp(GRADIENT_FROM[0], GRADIENT_TO[0], t);
+			const g = lerp(GRADIENT_FROM[1], GRADIENT_TO[1], t);
+			const b = lerp(GRADIENT_FROM[2], GRADIENT_TO[2], t);
+			return `[38;2;${r};${g};${b}m${char}[39m`;
+		})
+		.join('');
+}
+
+const BANNER = [
+	'  ▄▄▄▄▄  ▄▄▄  ▄▄▄    ▄▄ ▄▄▄',
+	' ▀█▄▄▄   ██   ██     ██▄█▀',
+	'  ▄▄▄█▀  ██   ██▄▄▄  ██ ▀█▄',
+	'  ▀▀▀▀  ▀▀▀▀ ▀▀▀▀▀▀ ▀▀▀  ▀▀'
+];
+
+/** Prints the silk banner with tagline. */
+export function banner(version: string) {
+	console.log();
+	for (const line of BANNER) console.log(gradientLine(line));
+	console.log();
+	console.log(
+		`  ${pc.bold('Silk UI')} ${pc.dim(`v${version}`)} ${pc.dim('·')} ${pc.dim('Svelte components you own')}`
+	);
+	console.log();
+}
+
+export const ok = (message: string) => console.log(`${pc.green('✔')} ${message}`);
+export const warn = (message: string) => console.log(`${pc.yellow('▲')} ${message}`);
+export const fail = (message: string) => console.error(`${pc.red('✖')} ${message}`);
+
+/** Renders a list of lines as a box-drawing tree under a heading. */
+export function tree(heading: string, lines: string[]) {
+	console.log(`  ${heading}`);
+	lines.forEach((line, i) => {
+		const branch = i === lines.length - 1 ? '└─' : '├─';
+		console.log(`  ${pc.dim(branch)} ${line}`);
+	});
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022"],
+		"types": ["bun-types"],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowImportingTsExtensions": true
+	},
+	"include": ["src/**/*.ts", "scripts/**/*.ts"]
+}

--- a/packages/silk/src/themes/transitions/index.ts
+++ b/packages/silk/src/themes/transitions/index.ts
@@ -1,24 +1,40 @@
 import type { ThemeTransitionPreset, ThemeTransitionPresetSlug, ThemeMotion } from './types';
 
-type ThemeTransitionPresetModule = {
-	preset?: ThemeTransitionPreset;
-	transition?: ThemeTransitionPreset;
-	defaultPreset?: ThemeTransitionPreset;
-};
+import { preset as bounce } from './bounce';
+import { preset as crisp } from './crisp';
+import { preset as defaultPreset } from './default';
+import { preset as dramatic } from './dramatic';
+import { preset as fade } from './fade';
+import { preset as gentle } from './gentle';
+import { preset as glide } from './glide';
+import { preset as instant } from './instant';
+import { preset as none } from './none';
+import { preset as smooth } from './smooth';
+import { preset as snappy } from './snappy';
+import { preset as spring } from './spring';
+import { preset as swift } from './swift';
 
-const transitionModules = import.meta.glob('./*.ts', { eager: true }) as Record<
-	string,
-	ThemeTransitionPresetModule
->;
-
-export const transitionPresets = Object.values(transitionModules)
-	.map((module) => module.preset ?? module.transition ?? module.defaultPreset ?? null)
-	.filter((preset): preset is ThemeTransitionPreset => Boolean(preset))
-	.sort((left, right) => {
-		if (left.slug === 'default') return -1;
-		if (right.slug === 'default') return 1;
-		return left.name.localeCompare(right.name);
-	});
+// Static imports (not import.meta.glob) so this module also loads outside
+// Vite -- the CLI registry build imports themeToCss under bun.
+export const transitionPresets: ThemeTransitionPreset[] = [
+	bounce,
+	crisp,
+	defaultPreset,
+	dramatic,
+	fade,
+	gentle,
+	glide,
+	instant,
+	none,
+	smooth,
+	snappy,
+	spring,
+	swift
+].sort((left, right) => {
+	if (left.slug === 'default') return -1;
+	if (right.slug === 'default') return 1;
+	return left.name.localeCompare(right.name);
+});
 
 export function getTransitionPreset(slug: ThemeTransitionPresetSlug) {
 	return transitionPresets.find((preset) => preset.slug === slug) ?? transitionPresets[0];

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
 		},
 		"build": {
 			"dependsOn": ["^build", "check"],
-			"outputs": ["build/**", ".svelte-kit/**", "dist/**", "prisma/generated/**"]
+			"outputs": ["build/**", ".svelte-kit/**", "dist/**", "prisma/generated/**", "registry/**"]
 		},
 		"check": {
 			"dependsOn": ["^check"]


### PR DESCRIPTION
# shadcn-style CLI for Silk UI

New workspace package `packages/cli` (npm name **`@silk-ui/cli`**, bin **`silk`**). It copies component source into the consumer's project — you own the code, there is no runtime library dependency. Follows the design from #25 / #31–#36 and consumes the per-component `manifest.ts` files that `packages/silk` already ships.

```bash
npx @silk-ui/cli init
npx @silk-ui/cli add command   # pulls popover + button transitively
npx @silk-ui/cli add theme default
npx @silk-ui/cli list
```

## Commands

- **`silk init`** — writes `silk.json` (install dir, import alias, theme registry URL), installs the `ui.css` theme tokens, `utils.ts`, and `internals/*`, and reports missing peer deps. Interactive clack prompts, or `--yes` for defaults (`src/lib/silk`, `$lib/silk`).
- **`silk add <component...>`** — resolves transitive deps from the manifests (e.g. `modal` pulls `button` + `_internal/overlay`), copies files, rewrites `@silk/ui/*` imports to the configured alias, records installed versions in `silk.json`, and detects missing npm peers (offers to install with the lockfile-detected package manager). Existing files are skipped unless `--overwrite`. Internal components are rejected as direct targets, and typos get a did-you-mean suggestion.
- **`silk add theme <slug>`** — built-in presets resolve offline; other slugs are fetched from the theme registry API (`registry` in `silk.json`, default `https://silk-ui.dev/api`) and rendered with the existing `themeToCss()`. Writes `theme.css` next to `ui.css`.
- **`silk list`** — catalog of all 39 public components with versions + descriptions, plus built-in themes.

## How it works

`scripts/build-registry.ts` (run as part of `bun run build` / `test`) imports all 40 manifests from `packages/silk`, validates every referenced file and dependency edge, and snapshots `registry/index.json` + 218 source files + pre-rendered theme CSS into the package. The published CLI ships that snapshot, so `silk add` works fully offline; `manifest.ts` files are registry metadata and are not copied into consumer projects (versions are tracked in `silk.json` instead).

Terminal output: truecolor gradient banner in the brand ramp, clack intro/spinners/confirm prompts, box-drawing file trees with `+` / `~` / `=` markers per file.

## Other changes

- `packages/silk/src/themes/transitions/index.ts`: replaced `import.meta.glob` with static imports so `themeToCss` also loads outside Vite (the registry build runs under bun). Behavior unchanged — docs `svelte-check` and all 659 unit/ssr tests pass.
- `turbo.json`: added `registry/**` to build outputs; `.gitignore` / `.prettierignore` entries for the CLI build artifacts.
- Root README repo-layout updated.

## Testing

- 13 bun tests: dependency resolution (transitive, internal-target rejection, suggestions, peer-dep union), import rewriting, and snapshot integrity (every indexed file exists, every dep edge resolves, themes carry rendered CSS).
- `turbo check / lint / build` green for `@silk-ui/cli` + `docs`; `docs test:ci` 659/659 pass. (`registry#check` fails locally only because the sandbox blocks Prisma binary downloads.)
- End-to-end smoke test in a throwaway project: `init` → `add command` → `add modal` → `add theme default` → re-`add` (skip-existing), verifying rewritten imports and `silk.json` bookkeeping.

Closes #25

https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS)_