### PR TITLE
ci: publish @silk-ui/cli to npm on release

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,73 @@
+name: Publish CLI
+
+# Publishes @silk-ui/cli to npm when a GitHub release is published.
+# Tag the release `cli-v<version>` or `v<version>`, matching the version
+# in packages/cli/package.json. Requires the NPM_TOKEN repository secret.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    name: Publish @silk-ui/cli to npm
+    runs-on: ubuntu-latest
+    env:
+      LEFTHOOK: 0
+      TURBO_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Setup Node (npm registry auth)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          version=$(node -p "require('./packages/cli/package.json').version")
+          tag="${GITHUB_REF_NAME#cli-}"
+          tag="${tag#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "release tag $GITHUB_REF_NAME does not match @silk-ui/cli version $version" >&2
+            exit 1
+          fi
+
+      - name: Typecheck
+        run: bun --filter='@silk-ui/cli' run check
+
+      - name: Test
+        run: bun --filter='@silk-ui/cli' run test
+
+      - name: Build
+        run: bun --filter='@silk-ui/cli' run build
+
+      - name: Publish to npm
+        working-directory: packages/cli
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,9 @@
 	"description": "Install Silk UI components into your Svelte project. Owns-the-code distribution, shadcn style.",
 	"type": "module",
 	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
+	},
 	"bin": {
 		"silk": "./dist/index.js"
 	},


### PR DESCRIPTION
# Publish @silk-ui/cli to npm on release

Adds `.github/workflows/publish-cli.yml`, triggered when a GitHub release is published (plus `workflow_dispatch` for manual runs). Follow-up to #76; covers the publish half of the old #35.

## What it does

1. Bun install (same setup/caching as `ci.yml`), with Node configured for npm registry auth.
2. **Tag guard** — the release tag must match `packages/cli/package.json`'s version; both `cli-v0.1.0` and `v0.1.0` formats are accepted. A mismatch fails before anything publishes. (Skipped on manual dispatch.)
3. Typecheck → tests → build (registry snapshot + bundle) scoped to `@silk-ui/cli`.
4. `npm publish --provenance --access public` from `packages/cli`.

Also sets `publishConfig.access: public` on the scoped package so a manual `npm publish` behaves identically.

## Setup required

Add an **`NPM_TOKEN`** repository secret — an npm automation token with publish rights for the `@silk-ui` scope. Provenance needs no extra setup; the workflow grants `id-token: write`.

## Testing

- YAML validated; tag-strip logic checked for both accepted tag formats.
- `npm publish --dry-run` from `packages/cli` after a fresh build: 112 kB tarball containing `dist/` and the `registry/` snapshot as intended.

https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS)_