### PR TITLE
docs: standardize component pages on a shared doc-kit (Button as the reference)

### DIFF
--- a/apps/docs/src/lib/components/docs/doc-footer.svelte
+++ b/apps/docs/src/lib/components/docs/doc-footer.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Button } from '@silk/ui/components/button';
+	import ArrowRight from '@lucide/svelte/icons/arrow-right';
+
+	/** Standard "restyle in the studio" call-to-action that closes every page. */
+</script>
+
+<section
+	class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
+>
+	<div class="flex flex-col gap-1">
+		<p
+			class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
+			style="font-family: var(--font-header);"
+		>
+			Want to make it yours?
+		</p>
+		<p class="m-0 text-[0.86rem] text-foreground-muted">
+			Every Silk component reads from your theme tokens — open the studio to restyle them.
+		</p>
+	</div>
+	<Button href="/themes/studio">
+		Open theme studio
+		<ArrowRight size={14} />
+	</Button>
+</section>

--- a/apps/docs/src/lib/components/docs/doc-header.svelte
+++ b/apps/docs/src/lib/components/docs/doc-header.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { Badge } from '@silk/ui/components/badge';
+	import Component from '@lucide/svelte/icons/component';
+	import External from '@lucide/svelte/icons/external-link';
+	import Hash from '@lucide/svelte/icons/hash';
+	import Copy from '@lucide/svelte/icons/copy';
+	import Check from '@lucide/svelte/icons/check';
+	import { createCopy } from '$lib/copy.svelte';
+
+	export type HeaderPill = { label: string; variant?: 'outlined' | 'ghost' };
+
+	/**
+	 * The standard component-page hero: a "Component" badge plus optional pills,
+	 * a "View source" link, the title and lead paragraph, and a copyable install
+	 * command. Every component page opens with this so the framing is identical.
+	 */
+	let {
+		title,
+		description,
+		source,
+		install,
+		pills = []
+	}: {
+		title: string;
+		description: string;
+		source: string;
+		install: string;
+		pills?: HeaderPill[];
+	} = $props();
+
+	const clip = createCopy();
+</script>
+
+<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
+	<div class="flex flex-wrap items-start justify-between gap-3">
+		<div class="flex flex-wrap items-center gap-2">
+			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]">
+				Component
+			</Badge>
+			{#each pills as pill}
+				<Badge variant={pill.variant ?? 'ghost'} class="text-[0.66rem]">{pill.label}</Badge>
+			{/each}
+		</div>
+		<a
+			href={source}
+			target="_blank"
+			rel="noreferrer noopener"
+			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
+		>
+			View source
+			<External size={11} />
+		</a>
+	</div>
+
+	<div class="flex flex-col gap-3">
+		<h1
+			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
+			style="font-family: var(--font-header);"
+		>
+			{title}
+		</h1>
+		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
+			{description}
+		</p>
+	</div>
+
+	<div
+		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
+	>
+		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
+			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
+				<Hash size={12} />
+			</span>
+			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{install}</code>
+		</div>
+		<button
+			type="button"
+			onclick={() => clip.copy(install, 'install')}
+			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
+			aria-label="Copy install command"
+		>
+			{#if clip.copied('install')}
+				<Check size={14} class="text-[var(--color-success)]" />
+			{:else}
+				<Copy size={14} />
+			{/if}
+		</button>
+	</div>
+</header>

--- a/apps/docs/src/lib/components/docs/doc-pager.svelte
+++ b/apps/docs/src/lib/components/docs/doc-pager.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { Button } from '@silk/ui/components/button';
+	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import { components, sanitizeComponent } from '$lib/components';
+
+	/** Prev / next component navigation, ordered by the shared components list. */
+	let { slug }: { slug: string } = $props();
+
+	const curIndex = $derived(components.indexOf(slug));
+	const prevComponent = $derived(components[curIndex - 1]);
+	const nextComponent = $derived(components[curIndex + 1]);
+</script>
+
+{#if curIndex !== -1}
+	<div
+		class="mt-12 flex w-full items-center"
+		class:justify-between={prevComponent && nextComponent}
+		class:justify-end={!prevComponent && nextComponent}
+		class:justify-start={prevComponent && !nextComponent}
+	>
+		{#if prevComponent}
+			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
+				<ChevronLeft size={16} />
+				{sanitizeComponent(prevComponent)}
+			</Button>
+		{/if}
+		{#if prevComponent && nextComponent}
+			<div class="mx-4 w-full rounded-lg border-t"></div>
+		{/if}
+		{#if nextComponent}
+			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
+				{sanitizeComponent(nextComponent)}
+				<ChevronRight size={16} />
+			</Button>
+		{/if}
+	</div>
+{/if}

--- a/apps/docs/src/lib/components/docs/doc-section.svelte
+++ b/apps/docs/src/lib/components/docs/doc-section.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+
+	/**
+	 * A standard docs body section: an icon-chip + heading, an optional lead
+	 * paragraph, then the section's content. Every component page composes its
+	 * body from these so headings, spacing, and the on-this-page TOC stay
+	 * consistent. The `<h2>` is plain so the TOC picks it up.
+	 */
+	let {
+		icon: Icon,
+		title,
+		description,
+		id,
+		children
+	}: {
+		icon: Component<{ size?: number | string; class?: string }>;
+		title: string;
+		description?: string;
+		id?: string;
+		children: Snippet;
+	} = $props();
+</script>
+
+<section {id} class="scroll-mt-20 flex flex-col gap-5">
+	<div class="flex flex-col gap-1">
+		<div class="flex items-center gap-2">
+			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
+				<Icon size={12} />
+			</span>
+			<h2
+				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
+				style="font-family: var(--font-header);"
+			>
+				{title}
+			</h2>
+		</div>
+		{#if description}
+			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">{description}</p>
+		{/if}
+	</div>
+	{@render children()}
+</section>

--- a/apps/docs/src/lib/components/docs/prop-table.svelte
+++ b/apps/docs/src/lib/components/docs/prop-table.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import Copy from '@lucide/svelte/icons/copy';
+	import Check from '@lucide/svelte/icons/check';
+	import { createCopy } from '$lib/copy.svelte';
+
+	export type PropRow = {
+		/** Sub-part of a compound component, e.g. `Root` -> `Accordion.Root`. */
+		component?: string;
+		prop: string;
+		type: string;
+		default: string;
+		description: string;
+	};
+
+	/**
+	 * The standard API reference table. Renders a header row, click-to-copy prop
+	 * names, the type signature, a description, and the default. Pass `namespace`
+	 * for compound components so rows label as `<namespace>.<component>`.
+	 */
+	let {
+		rows,
+		namespace
+	}: {
+		rows: PropRow[];
+		namespace?: string;
+	} = $props();
+
+	const clip = createCopy();
+</script>
+
+<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
+	<div
+		class="grid grid-cols-[1fr_1.8fr_0.5fr] gap-3 border-b border-border bg-secondary/40 px-4 py-2.5 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted max-md:hidden"
+	>
+		<span>Prop</span>
+		<span>Type</span>
+		<span class="text-right">Default</span>
+	</div>
+	<ul class="flex flex-col divide-y divide-border/60">
+		{#each rows as row}
+			<li class="grid grid-cols-[1fr_1.8fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
+				<div class="flex flex-col gap-1">
+					{#if row.component}
+						<code class="font-mono text-[0.7rem] text-foreground-muted">
+							{namespace ? `${namespace}.${row.component}` : row.component}
+						</code>
+					{/if}
+					{#if row.prop && row.prop !== '--'}
+						<button
+							type="button"
+							onclick={() => clip.copy(row.prop, `prop-${row.component ?? ''}-${row.prop}`)}
+							class="group inline-flex w-fit items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-secondary/60"
+						>
+							<code
+								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)] text-foreground"
+							>
+								{row.prop}
+							</code>
+							{#if clip.copied(`prop-${row.component ?? ''}-${row.prop}`)}
+								<Check size={11} class="text-[var(--color-success)]" />
+							{:else}
+								<Copy
+									size={11}
+									class="text-foreground-muted opacity-0 transition-opacity group-hover:opacity-100"
+								/>
+							{/if}
+						</button>
+					{/if}
+				</div>
+				<div class="flex flex-col gap-1">
+					<code
+						class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
+					>
+						{row.type}
+					</code>
+					<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
+				</div>
+				<div class="md:text-right">
+					<code class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem] text-foreground">
+						{row.default}
+					</code>
+				</div>
+			</li>
+		{/each}
+	</ul>
+</div>

--- a/apps/docs/src/lib/components/docs/prop-table.svelte
+++ b/apps/docs/src/lib/components/docs/prop-table.svelte
@@ -76,7 +76,9 @@
 					<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
 				</div>
 				<div class="md:text-right">
-					<code class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem] text-foreground">
+					<code
+						class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem] text-foreground"
+					>
 						{row.default}
 					</code>
 				</div>

--- a/apps/docs/src/lib/copy.svelte.ts
+++ b/apps/docs/src/lib/copy.svelte.ts
@@ -1,0 +1,25 @@
+/**
+ * Clipboard helper for docs pages. Tracks which snippet was last copied so a
+ * single component can show a transient "copied" check on the right control.
+ *
+ *   const clip = createCopy();
+ *   <button onclick={() => clip.copy(code, 'snippet')}>
+ *     {#if clip.copied('snippet')}Copied{/if}
+ *   </button>
+ */
+export function createCopy(timeout = 1600) {
+	let key = $state<string | null>(null);
+
+	return {
+		/** True while `id` is the most recently copied key. */
+		copied: (id: string) => key === id,
+		copy(text: string, id: string) {
+			if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+			void navigator.clipboard.writeText(text);
+			key = id;
+			setTimeout(() => {
+				if (key === id) key = null;
+			}, timeout);
+		}
+	};
+}

--- a/apps/docs/src/routes/docs/components/accordion/+page.svelte
+++ b/apps/docs/src/routes/docs/components/accordion/+page.svelte
@@ -88,8 +88,8 @@
 						<Accordion.Item value="item-1">
 							<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
 							<Accordion.Content
-								>Yes — the trigger is a real button with `aria-expanded` and `aria-controls`, and the
-								content has `role="region"`.</Accordion.Content
+								>Yes — the trigger is a real button with `aria-expanded` and `aria-controls`, and
+								the content has `role="region"`.</Accordion.Content
 							>
 						</Accordion.Item>
 						<Accordion.Item value="item-2">

--- a/apps/docs/src/routes/docs/components/accordion/+page.svelte
+++ b/apps/docs/src/routes/docs/components/accordion/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as Accordion from '@silk/ui/components/accordion';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Accordion';
 	const SLUG = 'accordion';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -64,74 +57,20 @@
 			description: 'Header button and the revealed region.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
-<svelte:head
-	><title>Silk · {TITLE}</title><meta
-		name="description"
-		content="Stacked collapsible sections — single or multi-open."
-	/></svelte:head
->
+<svelte:head>
+	<title>Silk · {TITLE}</title>
+	<meta name="description" content="Stacked collapsible sections — single or multi-open." />
+</svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Single + Multiple</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Stacked Collapsibles with shared state. Single mode acts like a radio; multiple lets users
-			open any combination.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Stacked Collapsibles with shared state. Single mode acts like a radio; multiple lets users open any combination."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Single + Multiple' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -149,8 +88,8 @@
 						<Accordion.Item value="item-1">
 							<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
 							<Accordion.Content
-								>Yes — the trigger is a real button with `aria-expanded` and `aria-controls`, and
-								the content has `role="region"`.</Accordion.Content
+								>Yes — the trigger is a real button with `aria-expanded` and `aria-controls`, and the
+								content has `role="region"`.</Accordion.Content
 							>
 						</Accordion.Item>
 						<Accordion.Item value="item-2">
@@ -186,83 +125,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Accordion.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Accordion" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/alert-dialog/+page.svelte
+++ b/apps/docs/src/routes/docs/components/alert-dialog/+page.svelte
@@ -1,27 +1,24 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as AlertDialog from '@silk/ui/components/alert-dialog';
 	import * as Tabs from '@silk/ui/components/tabs';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Trash from '@lucide/svelte/icons/trash-2';
 
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/alert-dialog';
-
-	const curIndex = components.indexOf('alert-dialog');
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const TITLE = 'Alert Dialog';
+	const SLUG = 'alert-dialog';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgTitle = $state('Delete this workspace?');
 	let pgDescription = $state(
@@ -110,17 +107,7 @@
   </AlertDialog.Content>
 </AlertDialog.Root>`);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add alert-dialog';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
@@ -131,63 +118,17 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">9 sub-components</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Composable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Alert Dialog
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A modal that stops everything to ask one question. Reach for it when an action is expensive,
-			irreversible, or affects other people. If the user can shrug and undo, use a Toast instead.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
-				<Hash size={12} />
-			</span>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}
-				<Check size={14} class="text-[var(--color-success)]" />
-			{:else}
-				<Copy size={14} />
-			{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A modal that stops everything to ask one question. Reach for it when an action is expensive, irreversible, or affects other people. If the user can shrug and undo, use a Toast instead."
+	source={SOURCE}
+	install={installCommand}
+	pills={[
+		{ label: 'v0.4.2', variant: 'outlined' },
+		{ label: '9 sub-components' },
+		{ label: 'Composable' }
+	]}
+/>
 
 <!-- ─── Playground ──────────────────────────────────────────────── -->
 <section class="pt-10">
@@ -256,10 +197,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}
+					{#if clip.copied('playground')}
 						<Check size={11} class="text-[var(--color-success)]" />
 						Copied
 					{:else}
@@ -277,25 +218,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- USAGE PATTERNS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Layers size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Patterns
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Two situations make up 90% of Alert Dialogs in real products.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Patterns"
+		description="Two situations make up 90% of Alert Dialogs in real products."
+	>
 		<Tabs.Root value="destructive">
 			<Tabs.List>
 				<Tabs.Trigger value="destructive">Destructive confirmation</Tabs.Trigger>
@@ -392,95 +319,13 @@
 				</Tabs.Content>
 			</div>
 		</Tabs.Root>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Hash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="AlertDialog" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>AlertDialog.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}
-			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
-				<ChevronLeft size={16} />
-				{sanitizeComponent(prevComponent)}
-			</Button>
-		{/if}
-		{#if prevComponent && nextComponent}
-			<div class="mx-4 w-full rounded-lg border-t"></div>
-		{/if}
-		{#if nextComponent}
-			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
-				{sanitizeComponent(nextComponent)}
-				<ChevronRight size={16} />
-			</Button>
-		{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/alert/+page.svelte
+++ b/apps/docs/src/routes/docs/components/alert/+page.svelte
@@ -1,27 +1,24 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Alert from '@silk/ui/components/alert';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
 	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
 	import Wand from '@lucide/svelte/icons/wand-sparkles';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Alert';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/alert';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'alert';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	type Variant = 'info' | 'success' | 'warning' | 'error';
 	let pgVariant = $state<Variant>('info');
@@ -96,85 +93,28 @@
   </Alert.Description>
 </Alert.Root>`);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add alert';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
-	<title>Silk · Alert</title>
+	<title>Silk · {TITLE}</title>
 	<meta
 		name="description"
 		content="Tinted callouts for inline status, confirmation, and warnings."
 	/>
 </svelte:head>
 
-<!-- ─── Hero ─────────────────────────────────────────────────────── -->
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">4 variants</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">3 sub-components</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Alert
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			An inline callout that grabs attention without stealing focus. Drop one above a form, beside a
-			setting, or wherever the user needs context they didn't ask for.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
-				<Hash size={12} />
-			</span>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}
-				<Check size={14} class="text-[var(--color-success)]" />
-			{:else}
-				<Copy size={14} />
-			{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="An inline callout that grabs attention without stealing focus. Drop one above a form, beside a setting, or wherever the user needs context they didn't ask for."
+	source={SOURCE}
+	install={installCommand}
+	pills={[
+		{ label: 'v0.4.2', variant: 'outlined' },
+		{ label: '4 variants' },
+		{ label: '3 sub-components' }
+	]}
+/>
 
 <!-- ─── Playground ──────────────────────────────────────────────── -->
 <section class="pt-10">
@@ -251,10 +191,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}
+					{#if clip.copied('playground')}
 						<Check size={11} class="text-[var(--color-success)]" />
 						Copied
 					{:else}
@@ -273,26 +213,11 @@
 
 <!-- ─── Body sections ──────────────────────────────────────────── -->
 <div class="flex flex-col gap-16 pt-16">
-	<!-- VARIANTS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Layers size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Variants
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Variant maps to intent, not severity. Pick the one that matches what the user should think
-				when they see it.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Variants"
+		description="Variant maps to intent, not severity. Pick the one that matches what the user should think when they see it."
+	>
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
 			{#each variantList as v}
 				<div
@@ -311,13 +236,13 @@
 						<button
 							type="button"
 							onclick={() =>
-								copy(
+								clip.copy(
 									`<Alert.Root${v.value !== 'info' ? ` variant="${v.value}"` : ''}>\n  <Alert.Title>${v.label}</Alert.Title>\n  <Alert.Description>${v.use}</Alert.Description>\n</Alert.Root>`,
 									`var-${v.value}`
 								)}
 							class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.7rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 						>
-							{#if copiedSnippet === `var-${v.value}`}
+							{#if clip.copied(`var-${v.value}`)}
 								<Check size={11} class="text-[var(--color-success)]" />
 								Copied
 							{:else}
@@ -329,27 +254,13 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- ANATOMY -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Component size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Anatomy
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Three composable pieces. Skip the description if a title alone says enough.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Component}
+		title="Anatomy"
+		description="Three composable pieces. Skip the description if a title alone says enough."
+	>
 		<div class="grid gap-3 md:grid-cols-2">
 			<div
 				class="grid place-items-center rounded-[var(--radius-lg)] border border-border bg-card p-8"
@@ -370,24 +281,9 @@
 					)}</code
 				></pre>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- USAGE -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Wand size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					When to use it
-				</h2>
-			</div>
-		</div>
-
+	<DocSection icon={Wand} title="When to use it">
 		<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
 			<div class="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-border bg-card p-4">
 				<span
@@ -418,95 +314,13 @@
 				</ul>
 			</div>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Hash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{row.component}</code>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<!-- FOOTER -->
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-<!-- ─── Prev / next ─────────────────────────────────────────── -->
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}
-			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
-				<ChevronLeft size={16} />
-				{sanitizeComponent(prevComponent)}
-			</Button>
-		{/if}
-		{#if prevComponent && nextComponent}
-			<div class="mx-4 w-full rounded-lg border-t"></div>
-		{/if}
-		{#if nextComponent}
-			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
-				{sanitizeComponent(nextComponent)}
-				<ChevronRight size={16} />
-			</Button>
-		{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/avatar/+page.svelte
+++ b/apps/docs/src/routes/docs/components/avatar/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as Avatar from '@silk/ui/components/avatar';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Avatar';
 	const SLUG = 'avatar';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -57,17 +50,6 @@
 			description: 'Rendered until the image loads (or if it errors).'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -77,53 +59,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Image + Fallback</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Render an image with initials as a fallback. Comes in four sizes and two shapes.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Render an image with initials as a fallback. Comes in four sizes and two shapes."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Image + Fallback' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -156,83 +98,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Avatar.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Avatar" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/badge/+page.svelte
+++ b/apps/docs/src/routes/docs/components/badge/+page.svelte
@@ -1,26 +1,23 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
 	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import CircleDot from '@lucide/svelte/icons/circle-dot';
 
 	const TITLE = 'Badge';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/badge';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'badge';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	type Variant =
 		| 'primary'
@@ -74,80 +71,21 @@
 		`<Badge${pgVariant !== 'primary' ? ` variant="${pgVariant}"` : ''}>${pgLabel || 'Badge'}</Badge>`
 	);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add badge';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
-	<title>Silk · Badge</title>
+	<title>Silk · {TITLE}</title>
 	<meta name="description" content="Small status tags and metadata pills for any UI surface." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">7 variants</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Badge
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A compact label for status, counts, tags, and metadata. Same variant grammar as Button so the
-			two stack naturally.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
-				<Hash size={12} />
-			</span>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}
-				<Check size={14} class="text-[var(--color-success)]" />
-			{:else}
-				<Copy size={14} />
-			{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A compact label for status, counts, tags, and metadata. Same variant grammar as Button so the two stack naturally."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: '7 variants' }]}
+/>
 
 <!-- Playground -->
 <section class="pt-10">
@@ -206,10 +144,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}
+					{#if clip.copied('playground')}
 						<Check size={11} class="text-[var(--color-success)]" />
 						Copied
 					{:else}
@@ -227,25 +165,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- VARIANTS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Layers size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Variants
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Match the badge's variant to whatever it's labeling — keep status colors for actual status.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Variants"
+		description="Match the badge's variant to whatever it's labeling — keep status colors for actual status."
+	>
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 			{#each variantList as v}
 				<div
@@ -258,13 +182,13 @@
 					<button
 						type="button"
 						onclick={() =>
-							copy(
+							clip.copy(
 								`<Badge${v.value !== 'primary' ? ` variant="${v.value}"` : ''}>${v.label}</Badge>`,
 								`var-${v.value}`
 							)}
 						class="inline-flex w-fit items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.7rem] text-foreground-muted opacity-0 transition-opacity hover:bg-secondary/60 hover:text-foreground group-hover:opacity-100"
 					>
-						{#if copiedSnippet === `var-${v.value}`}
+						{#if clip.copied(`var-${v.value}`)}
 							<Check size={11} class="text-[var(--color-success)]" />
 							Copied
 						{:else}
@@ -275,27 +199,9 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- COMMON PATTERNS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<CircleDot size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Patterns
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Three places Badge earns its keep.
-			</p>
-		</div>
-
+	<DocSection icon={CircleDot} title="Patterns" description="Three places Badge earns its keep.">
 		<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
 			<div
 				class="flex flex-col items-start gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4"
@@ -328,90 +234,13 @@
 				<Badge variant="outlined">design</Badge>
 			</div>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Hash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}
-			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
-				<ChevronLeft size={16} />
-				{sanitizeComponent(prevComponent)}
-			</Button>
-		{/if}
-		{#if prevComponent && nextComponent}
-			<div class="mx-4 w-full rounded-lg border-t"></div>
-		{/if}
-		{#if nextComponent}
-			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
-				{sanitizeComponent(nextComponent)}
-				<ChevronRight size={16} />
-			</Button>
-		{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/breadcrumb/+page.svelte
+++ b/apps/docs/src/routes/docs/components/breadcrumb/+page.svelte
@@ -1,27 +1,21 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Breadcrumb from '@silk/ui/components/breadcrumb';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Slash from '@lucide/svelte/icons/slash';
 	import Home from '@lucide/svelte/icons/home';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
 	const TITLE = 'Breadcrumb';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/breadcrumb';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'breadcrumb';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -47,18 +41,6 @@
 			description: 'Custom separator (swap for an icon like ChevronRight or Slash).'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add breadcrumb';
 </script>
 
 <svelte:head>
@@ -66,62 +48,13 @@
 	<meta name="description" content="A trail of links showing the user's position in a hierarchy." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">3 sub-components</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Breadcrumb
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Shows where the user is in a nested hierarchy and lets them jump back up. Keep them short — if
-			you need more than five items, your hierarchy is probably the problem.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
-				<Hash size={12} />
-			</span>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}
-				<Check size={14} class="text-[var(--color-success)]" />
-			{:else}
-				<Copy size={14} />
-			{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Shows where the user is in a nested hierarchy and lets them jump back up. Keep them short — if you need more than five items, your hierarchy is probably the problem."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: '3 sub-components' }]}
+/>
 
 <!-- Playground / preview -->
 <section class="pt-10">
@@ -161,26 +94,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- SEPARATORS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Slash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Separators
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Three common choices. Pick one and use it everywhere — mixing separators in the same app
-				looks accidental.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Slash}
+		title="Separators"
+		description="Three common choices. Pick one and use it everywhere — mixing separators in the same app looks accidental."
+	>
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
 			<div
 				class="flex flex-col items-start gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4"
@@ -224,24 +142,9 @@
 				</Breadcrumb.Root>
 			</div>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- WITH ICON -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Home size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					With a home icon
-				</h2>
-			</div>
-		</div>
-
+	<DocSection icon={Home} title="With a home icon">
 		<div class="grid gap-3 md:grid-cols-2">
 			<div
 				class="grid place-items-center rounded-[var(--radius-lg)] border border-border bg-card p-6"
@@ -276,95 +179,13 @@
 					)}</code
 				></pre>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Hash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Breadcrumb" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Breadcrumb.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}
-			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
-				<ChevronLeft size={16} />
-				{sanitizeComponent(prevComponent)}
-			</Button>
-		{/if}
-		{#if prevComponent && nextComponent}
-			<div class="mx-4 w-full rounded-lg border-t"></div>
-		{/if}
-		{#if nextComponent}
-			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
-				{sanitizeComponent(nextComponent)}
-				<ChevronRight size={16} />
-			</Button>
-		{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/button/+page.svelte
+++ b/apps/docs/src/routes/docs/components/button/+page.svelte
@@ -341,7 +341,9 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 	<DocSection icon={Sparkles} title="At a glance" id="overview">
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
 			{#each [{ icon: Layers, title: '10 variants', body: 'Semantic + status + neutral.' }, { icon: Type, title: '4 sizes', body: 'Token-driven height + padding.' }, { icon: Link, title: 'Polymorphic', body: 'Pass `href` to render an anchor.' }] as card}
-				<div class="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-border bg-card p-4">
+				<div
+					class="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-border bg-card p-4"
+				>
 					<span class="grid size-8 place-items-center rounded-md bg-secondary/60 text-foreground">
 						<card.icon size={14} />
 					</span>
@@ -368,7 +370,7 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 	<DocSection
 		icon={Layers}
 		title="Variants"
-		description={`Pick by intent. The same action ("Save") should always use the same variant across your product.`}
+		description="Pick by intent. The same action (Save) should always use the same variant across your product."
 		id="variants"
 	>
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/docs/src/routes/docs/components/button/+page.svelte
+++ b/apps/docs/src/routes/docs/components/button/+page.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
 	import { Button, type ButtonVariant } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Tabs from '@silk/ui/components/tabs';
-	import * as Tooltip from '@silk/ui/components/tooltip';
 	import * as Alert from '@silk/ui/components/alert';
 	import { toast } from '@silk/ui/components/toast';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
 	import Component from '@lucide/svelte/icons/component';
@@ -29,11 +30,9 @@
 	import Hash from '@lucide/svelte/icons/hash';
 
 	const TITLE = 'Button';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/button';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'button';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	// ── Playground state ─────────────────────────────────────────────────
 	type Size = 'sm' | 'default' | 'lg' | 'icon';
@@ -187,17 +186,7 @@
 ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 </Button>`);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add button';
+	const clip = createCopy();
 
 	async function runLoadingDemo() {
 		pgLoading = true;
@@ -213,71 +202,20 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 </script>
 
 <svelte:head>
-	<title>Silk · Button</title>
+	<title>Silk · {TITLE}</title>
 	<meta
 		name="description"
 		content="Displays a button or a component that looks like a button. Ten variants, four sizes, polymorphic href."
 	/>
 </svelte:head>
 
-<!-- ─── Hero ─────────────────────────────────────────────────────── -->
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">10 variants</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">4 sizes</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Button
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			The most touched piece of UI in your product. Silk's Button is built around semantic intent —
-			pick a variant for what the action means, not how it should look.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted">
-				<Hash size={12} />
-			</span>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}
-				<Check size={14} class="text-[var(--color-success)]" />
-			{:else}
-				<Copy size={14} />
-			{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="The most touched piece of UI in your product. Silk's Button is built around semantic intent — pick a variant for what the action means, not how it should look."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: '10 variants' }, { label: '4 sizes' }]}
+/>
 
 <!-- ─── Playground (vertical layout) ───────────────────────────── -->
 <section class="pt-10">
@@ -378,10 +316,10 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				</span>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}
+					{#if clip.copied('playground')}
 						<Check size={11} class="text-[var(--color-success)]" />
 						Copied
 					{:else}
@@ -400,24 +338,10 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 
 <!-- ─── Body sections ──────────────────────────────────────────── -->
 <div class="flex flex-col gap-16 pt-16">
-	<!-- OVERVIEW -->
-	<section id="overview" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-				<Sparkles size={12} />
-			</span>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				At a glance
-			</h2>
-		</div>
+	<DocSection icon={Sparkles} title="At a glance" id="overview">
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
 			{#each [{ icon: Layers, title: '10 variants', body: 'Semantic + status + neutral.' }, { icon: Type, title: '4 sizes', body: 'Token-driven height + padding.' }, { icon: Link, title: 'Polymorphic', body: 'Pass `href` to render an anchor.' }] as card}
-				<div
-					class="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-border bg-card p-4"
-				>
+				<div class="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-border bg-card p-4">
 					<span class="grid size-8 place-items-center rounded-md bg-secondary/60 text-foreground">
 						<card.icon size={14} />
 					</span>
@@ -439,28 +363,14 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				follow — no styling overrides required.
 			</Alert.Description>
 		</Alert.Root>
-	</section>
+	</DocSection>
 
-	<!-- VARIANTS -->
-	<section id="variants" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Layers size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Variants
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Pick by intent. The same action ("Save") should always use the same variant across your
-				product.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Variants"
+		description={`Pick by intent. The same action ("Save") should always use the same variant across your product.`}
+		id="variants"
+	>
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 			{#each variantList as v}
 				{@const code = `<Button${v.value !== 'primary' ? ` variant="${v.value}"` : ''}>${v.label}</Button>`}
@@ -481,11 +391,11 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 							</p>
 							<button
 								type="button"
-								onclick={() => copy(code, `var-${v.value}`)}
+								onclick={() => clip.copy(code, `var-${v.value}`)}
 								class="grid size-6 place-items-center rounded text-foreground-muted opacity-0 transition-opacity hover:bg-secondary/50 hover:text-foreground group-hover:opacity-100"
 								aria-label={`Copy ${v.label} snippet`}
 							>
-								{#if copiedSnippet === `var-${v.value}`}
+								{#if clip.copied(`var-${v.value}`)}
 									<Check size={12} class="text-[var(--color-success)]" />
 								{:else}
 									<Copy size={12} />
@@ -502,27 +412,14 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- SIZES -->
-	<section id="sizes" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Type size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Sizes
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Sizes scale on a 4-unit baseline. Pick the smallest size that still feels clickable.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Type}
+		title="Sizes"
+		description="Sizes scale on a 4-unit baseline. Pick the smallest size that still feels clickable."
+		id="sizes"
+	>
 		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
 			<div
 				class="flex flex-wrap items-end justify-around gap-5 border-b border-border/70 bg-[linear-gradient(180deg,transparent,color-mix(in_srgb,var(--color-secondary)_45%,transparent))] px-6 py-8"
@@ -562,28 +459,14 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				{/each}
 			</div>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- STATES -->
-	<section id="states" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Wand size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					States
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				The same Button renders five distinct states. All transitions are tied to your theme's
-				motion preset.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Wand}
+		title="States"
+		description="The same Button renders five distinct states. All transitions are tied to your theme's motion preset."
+		id="states"
+	>
 		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
 			{#each [{ label: 'Resting', node: 'rest' }, { label: 'Hover', node: 'hover' }, { label: 'Focus', node: 'focus' }, { label: 'Active', node: 'active' }, { label: 'Disabled', node: 'disabled' }] as s}
 				<div
@@ -609,27 +492,14 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- COMPOSITION -->
-	<section id="composition" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Component size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Composition
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Patterns we use in production. Copy any of these as a starting point.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Component}
+		title="Composition"
+		description="Patterns we use in production. Copy any of these as a starting point."
+		id="composition"
+	>
 		<Tabs.Root value="leading">
 			<Tabs.List>
 				<Tabs.Trigger value="leading">Leading icon</Tabs.Trigger>
@@ -752,150 +622,21 @@ ${pgIcon ? '  <ArrowRight size={14} />\n' : ''}  ${pgLabel || 'Button'}
 				</Tabs.Content>
 			</div>
 		</Tabs.Root>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section id="api" class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-					<Hash size={12} />
-				</span>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				<code class="font-mono text-foreground">Button</code> is the only export. Every prop accepts the
-				underlying button/anchor attributes too.
-			</p>
-		</div>
-
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<div
-				class="grid grid-cols-[1fr_1.8fr_0.5fr] gap-3 border-b border-border bg-secondary/40 px-4 py-2.5 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted max-md:hidden"
-			>
-				<span>Prop</span>
-				<span>Type</span>
-				<span class="text-right">Default</span>
-			</div>
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.8fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex items-center gap-2">
-							<button
-								type="button"
-								onclick={() => copy(row.prop, `prop-${row.prop}`)}
-								class="group inline-flex items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-secondary/60"
-							>
-								<code
-									class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)] text-foreground"
-								>
-									{row.prop}
-								</code>
-								{#if copiedSnippet === `prop-${row.prop}`}
-									<Check size={11} class="text-[var(--color-success)]" />
-								{:else}
-									<Copy
-										size={11}
-										class="text-foreground-muted opacity-0 transition-opacity group-hover:opacity-100"
-									/>
-								{/if}
-							</button>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-							>
-								{row.type}
-							</code>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">
-								{row.description}
-							</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem] text-foreground"
-							>
-								{row.default}
-							</code>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<!-- FOOTER -->
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
+	<DocSection
+		icon={Hash}
+		title="API"
+		description="Button is the only export. Every prop accepts the underlying button/anchor attributes too."
+		id="api"
 	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Button token lives in the studio — restyle it for your brand in seconds.
-			</p>
-		</div>
-		<div class="flex flex-wrap items-center gap-2">
-			<Button variant="ghost" href={SOURCE}>
-				<svg viewBox="0 0 24 24" aria-hidden="true" class="size-3.5 fill-current">
-					<path
-						d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.92.58.1.79-.25.79-.55v-1.94c-3.2.7-3.88-1.54-3.88-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.78 1.2 1.78 1.2 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.78 0c2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.79 1.06.79 2.14v3.17c0 .31.21.66.8.55C20.21 21.38 23.5 17.07 23.5 12 23.5 5.65 18.35.5 12 .5z"
-					/>
-				</svg>
-				View source
-				<External size={11} class="text-foreground-muted" />
-			</Button>
-			<Tooltip.Root>
-				<Tooltip.Trigger>
-					<Button variant="outlined" href="/themes">
-						<Layers size={14} />
-						Browse themes
-					</Button>
-				</Tooltip.Trigger>
-				<Tooltip.Content>Community-published presets</Tooltip.Content>
-			</Tooltip.Root>
-			<Button href="/themes/studio">
-				Open studio
-				<ArrowRight size={14} />
-			</Button>
-		</div>
-	</section>
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-<!-- ─── Prev / next ─────────────────────────────────────────── -->
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}
-			<Button href={`/docs/components/${prevComponent}`} variant="outlined" class="flex-shrink-0">
-				<ChevronLeft size={16} />
-				{sanitizeComponent(prevComponent)}
-			</Button>
-		{/if}
-		{#if prevComponent && nextComponent}
-			<div class="mx-4 w-full rounded-lg border-t"></div>
-		{/if}
-		{#if nextComponent}
-			<Button href={`/docs/components/${nextComponent}`} variant="outlined" class="flex-shrink-0">
-				{sanitizeComponent(nextComponent)}
-				<ChevronRight size={16} />
-			</Button>
-		{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />
 
 <style>
 	.silk-checkbox {

--- a/apps/docs/src/routes/docs/components/calendar/+page.svelte
+++ b/apps/docs/src/routes/docs/components/calendar/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Calendar } from '@silk/ui/components/calendar';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Calendar';
 	const SLUG = 'calendar';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{ prop: 'value', type: 'Date', default: '--', description: 'Bindable selected date.' },
@@ -39,17 +32,6 @@
 	];
 
 	let date = $state<Date | undefined>();
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -59,55 +41,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Locale-aware</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A single-date calendar. Month names and weekday letters use the user's locale via <code
-				class="font-mono text-[0.82rem]">Intl</code
-			> — no date library required.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A single-date calendar. Month names and weekday letters use the user's locale via Intl — no date library required."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Locale-aware' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -131,81 +71,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/card/+page.svelte
+++ b/apps/docs/src/routes/docs/components/card/+page.svelte
@@ -1,28 +1,22 @@
 <script lang="ts">
 	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Card from '@silk/ui/components/card';
 	import * as Tabs from '@silk/ui/components/tabs';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 
 	const TITLE = 'Card';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/card';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'card';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -68,18 +62,6 @@
 			description: 'Action row. Right-align CTAs.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add card';
 </script>
 
 <svelte:head>
@@ -87,61 +69,13 @@
 	<meta name="description" content="Surface container for grouping related content." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">6 sub-components</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Card
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			The universal grouping surface. Use it for stat cards, dashboard tiles, settings sections,
-			anything that needs to feel like its own thing.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="The universal grouping surface. Use it for stat cards, dashboard tiles, settings sections, anything that needs to feel like its own thing."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: '6 sub-components' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -196,26 +130,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- COMPOSITIONS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Layers size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Compositions
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Cards work best when you only include the pieces you need. Header-only, content-only, or
-				fully composed — Silk doesn't enforce a structure.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Compositions"
+		description="Cards work best when you only include the pieces you need. Header-only, content-only, or fully composed — Silk doesn't enforce a structure."
+	>
 		<Tabs.Root value="stat">
 			<Tabs.List>
 				<Tabs.Trigger value="stat">Stat card</Tabs.Trigger>
@@ -326,90 +245,13 @@
 				</Tabs.Content>
 			</div>
 		</Tabs.Root>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Hash size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Card" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">Card.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/checkbox/+page.svelte
+++ b/apps/docs/src/routes/docs/components/checkbox/+page.svelte
@@ -1,26 +1,22 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { Checkbox } from '@silk/ui/components/checkbox';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Checkbox';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/checkbox';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'checkbox';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgChecked = $state(true);
 	let pgLabel = $state('Receive product updates');
@@ -64,17 +60,7 @@
   label="${pgLabel || 'Label'}"${pgDescription ? `\n  description="${pgDescription}"` : ''}
 />`);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add checkbox';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
@@ -82,61 +68,13 @@
 	<meta name="description" content="Single-state toggle for opt-ins and binary choices." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Bindable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Checkbox
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A single binary control. Use it when the choice is yes/no — for one-of-many, reach for radio
-			groups; for system-level toggles, use Switch.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A single binary control. Use it when the choice is yes/no — for one-of-many, reach for radio groups; for system-level toggles, use Switch."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Bindable' }]}
+/>
 
 <!-- Playground -->
 <section class="pt-10">
@@ -195,10 +133,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}<Check
+					{#if clip.copied('playground')}<Check
 							size={11}
 							class="text-[var(--color-success)]"
 						/>Copied{:else}<Copy size={11} />Copy code{/if}
@@ -213,22 +151,7 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- STATES -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Layers size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					States
-				</h2>
-			</div>
-		</div>
-
+	<DocSection icon={Layers} title="States">
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
 			{#each [{ label: 'Unchecked', value: false }, { label: 'Checked', value: true }, { label: 'Disabled', value: false, disabled: true }, { label: 'Disabled + on', value: true, disabled: true }] as state}
 				<div
@@ -245,86 +168,13 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Hash size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/collapsible/+page.svelte
+++ b/apps/docs/src/routes/docs/components/collapsible/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as Collapsible from '@silk/ui/components/collapsible';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 
 	const TITLE = 'Collapsible';
 	const SLUG = 'collapsible';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -53,17 +46,6 @@
 	];
 
 	let open = $state(true);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -73,54 +55,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">CSS height transition</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A single show/hide region. The expand/collapse animation runs on CSS grid-template-rows — no
-			JS height measurement.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A single show/hide region. The expand/collapse animation runs on CSS grid-template-rows — no JS height measurement."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'CSS height transition' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -170,83 +111,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Collapsible.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Collapsible" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/color-picker/+page.svelte
+++ b/apps/docs/src/routes/docs/components/color-picker/+page.svelte
@@ -1,25 +1,19 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { ColorPicker, type ColorOption } from '@silk/ui/components/color-picker';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Palette from '@lucide/svelte/icons/palette';
 
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/color-picker';
-
-	const curIndex = components.indexOf('color-picker');
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const TITLE = 'Color Picker';
+	const SLUG = 'color-picker';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgValue = $state('#5e6ad2');
 	let pgValueWithOptions = $state('#0284c7');
@@ -74,18 +68,6 @@
 	const playgroundCode = $derived(
 		`<ColorPicker value="${pgValue}" onValueChange={(v) => (color = v)} />`
 	);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add color-picker';
 </script>
 
 <svelte:head>
@@ -96,62 +78,13 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">HSV + HSL</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Hex input</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Color Picker
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A compact color picker built around the same primitives the Theme Studio uses. Drag the SB
-			plane, tune the hue, or punch in a hex — every change emits the same event.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A compact color picker built around the same primitives the Theme Studio uses. Drag the SB plane, tune the hue, or punch in a hex — every change emits the same event."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'HSV + HSL' }, { label: 'Hex input' }]}
+/>
 
 <!-- Playground -->
 <section class="pt-10">
@@ -185,25 +118,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- WITH PRESETS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Palette size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					With preset swatches
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Pass an array of <code class="font-mono text-foreground">ColorOption</code> to surface curated
-				picks below the HSV plane.
-			</p>
-		</div>
+	<DocSection icon={Palette} title="With preset swatches">
+		<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
+			Pass an array of <code class="font-mono text-foreground">ColorOption</code> to surface curated picks
+			below the HSV plane.
+		</p>
 
 		<div class="grid gap-3 md:grid-cols-2">
 			<div
@@ -235,28 +154,14 @@
 					)}</code
 				></pre>
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- Variants -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Palette size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Trigger variants
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Style the trigger the same way as Buttons. Defaults to <code
-					class="font-mono text-foreground">outlined</code
-				>.
-			</p>
-		</div>
+	<DocSection icon={Palette} title="Trigger variants">
+		<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
+			Style the trigger the same way as Buttons. Defaults to <code class="font-mono text-foreground"
+				>outlined</code
+			>.
+		</p>
 
 		<div class="grid gap-3 md:grid-cols-3">
 			{#each ['outlined', 'secondary', 'ghost'] as v}
@@ -277,86 +182,13 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Hash size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/combobox/+page.svelte
+++ b/apps/docs/src/routes/docs/components/combobox/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Combobox from '@silk/ui/components/combobox';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Combobox';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/combobox';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'combobox';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let selected = $state('next');
 	const frameworks = [
@@ -105,18 +98,6 @@
 		}
 	];
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add combobox';
-
 	const selectedFramework = $derived(frameworks.find((f) => f.value === selected) ?? frameworks[0]);
 </script>
 
@@ -125,61 +106,13 @@
 	<meta name="description" content="Searchable select for picking one item from a long list." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Fuzzy search</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Combobox
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A searchable Select. Pick this when the list of options is too long to scroll — typing to
-			filter is always faster than scanning.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A searchable Select. Pick this when the list of options is too long to scroll — typing to filter is always faster than scanning."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Fuzzy search' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -238,89 +171,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Hash size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Combobox" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Combobox.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/command/+page.svelte
+++ b/apps/docs/src/routes/docs/components/command/+page.svelte
@@ -1,19 +1,14 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Command from '@silk/ui/components/command';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Layers from '@lucide/svelte/icons/layers-3';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Search from '@lucide/svelte/icons/search';
 	import Plus from '@lucide/svelte/icons/plus';
 	import Settings from '@lucide/svelte/icons/settings';
@@ -22,11 +17,9 @@
 	import LayoutTemplate from '@lucide/svelte/icons/layout-template';
 
 	const TITLE = 'Command';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/command';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'command';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -93,18 +86,6 @@
 			description: 'Horizontal divider between groups.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add command';
 </script>
 
 <svelte:head>
@@ -115,62 +96,17 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Keyboard-first</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Fuzzy search</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Command
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A `⌘K` command palette for jumping between pages, firing actions, or searching across your
-			app. Items are matched by their `name` string — pack it with keywords your users will type.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			>
-			<code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A `⌘K` command palette for jumping between pages, firing actions, or searching across your app. Items are matched by their `name` string — pack it with keywords your users will type."
+	source={SOURCE}
+	install={installCommand}
+	pills={[
+		{ label: 'v0.4.2', variant: 'outlined' },
+		{ label: 'Keyboard-first' },
+		{ label: 'Fuzzy search' }
+	]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -254,26 +190,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- USAGE -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Layers size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Anatomy
-				</h2>
-			</div>
-			<p class="m-0 max-w-[42rem] text-[0.86rem] text-foreground-muted">
-				Eight pieces. The only required ones are Root, Trigger, Content, and Item — everything else
-				exists to organize.
-			</p>
-		</div>
-
+	<DocSection
+		icon={Layers}
+		title="Anatomy"
+		description="Eight pieces. The only required ones are Root, Trigger, Content, and Item — everything else exists to organize."
+	>
 		<div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
 			{#each ['Root', 'Trigger', 'Content', 'Search', 'Results', 'Group', 'Item', 'Separator'] as part}
 				<div class="rounded-[var(--radius-md)] border border-border bg-card px-3 py-2 text-center">
@@ -281,91 +202,13 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Hash size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					API
-				</h2>
-			</div>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Command" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Command.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/context-menu/+page.svelte
+++ b/apps/docs/src/routes/docs/components/context-menu/+page.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as ContextMenu from '@silk/ui/components/context-menu';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import MousePointer from '@lucide/svelte/icons/mouse-pointer-2';
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 	import Image from '@lucide/svelte/icons/image';
@@ -26,11 +21,10 @@
 	import FolderOpen from '@lucide/svelte/icons/folder-open';
 	import FileText from '@lucide/svelte/icons/file-text';
 
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/context-menu';
-
-	const curIndex = components.indexOf('context-menu');
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const TITLE = 'Context Menu';
+	const SLUG = 'context-menu';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -83,18 +77,6 @@
 			description: 'Nested submenu for grouped options.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add context-menu';
 </script>
 
 <svelte:head>
@@ -102,60 +84,13 @@
 	<meta name="description" content="A right-click menu of actions for the element underneath." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Right-click</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Context Menu
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A right-click menu for actions that apply to whatever the user clicked on. Same item grammar
-			as DropdownMenu — the only difference is what opens it.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A right-click menu for actions that apply to whatever the user clicked on. Same item grammar as DropdownMenu — the only difference is what opens it."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Right-click' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -208,238 +143,150 @@
 	</div>
 </section>
 
-<!-- More realistic examples -->
-<section class="pt-12 flex flex-col gap-5">
-	<div class="flex flex-col gap-1">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-				<Sparkles size={12} />
-			</span>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Real-world examples
-			</h2>
-		</div>
-		<p class="m-0 text-[0.86rem] text-foreground-muted">
-			Right-click any of these surfaces. Each one ships a different menu — that's the point.
-		</p>
-	</div>
-
-	<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-		<!-- File row -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
-			<span
-				class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-			>
-				File row
-			</span>
-			<ContextMenu.Root>
-				<ContextMenu.Trigger>
-					<div
-						class="flex items-center gap-3 rounded-[var(--radius-md)] border border-dashed border-border bg-secondary/30 px-3 py-3 cursor-default"
-					>
-						<FileText size={14} class="text-foreground-muted" />
-						<div class="flex flex-col">
-							<span
-								class="text-[0.84rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)]"
-								>brand-guidelines.fig</span
-							>
-							<span class="text-[0.7rem] text-foreground-muted">Edited 2h ago · 4.2 MB</span>
-						</div>
-					</div>
-				</ContextMenu.Trigger>
-				<ContextMenu.Content>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><FolderOpen size={13} /> Open</span>
-					</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Pencil size={13} /> Rename</span>
-					</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Copy2 size={13} /> Duplicate</span>
-					</ContextMenu.Item>
-					<ContextMenu.Separator />
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Star size={13} /> Star</span>
-					</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Tag size={13} /> Add label</span>
-					</ContextMenu.Item>
-					<ContextMenu.Separator />
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2 text-[var(--color-destructive)]"
-							><Trash size={13} /> Move to trash</span
-						>
-					</ContextMenu.Item>
-				</ContextMenu.Content>
-			</ContextMenu.Root>
-		</div>
-
-		<!-- Image -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
-			<span
-				class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-			>
-				Image
-			</span>
-			<ContextMenu.Root>
-				<ContextMenu.Trigger>
-					<div
-						class="grid h-24 place-items-center rounded-[var(--radius-md)] border border-border bg-[linear-gradient(135deg,color-mix(in_srgb,var(--color-primary)_30%,transparent),color-mix(in_srgb,var(--color-info)_30%,transparent))] cursor-default"
-					>
-						<Image size={20} class="text-foreground" />
-					</div>
-				</ContextMenu.Trigger>
-				<ContextMenu.Content>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Download size={13} /> Save image</span>
-					</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>
-						<span class="flex items-center gap-2"><Copy2 size={13} /> Copy image</span>
-					</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>Copy image address</ContextMenu.Item>
-					<ContextMenu.Separator />
-					<ContextMenu.Item callback={() => {}}>Open in new tab</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>Inspect</ContextMenu.Item>
-				</ContextMenu.Content>
-			</ContextMenu.Root>
-		</div>
-
-		<!-- Task card -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
-			<span
-				class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-			>
-				Task card
-			</span>
-			<ContextMenu.Root>
-				<ContextMenu.Trigger>
-					<div
-						class="flex flex-col gap-2 rounded-[var(--radius-md)] border border-border bg-background/40 p-3 cursor-default"
-					>
-						<div class="flex items-center justify-between gap-2">
-							<span
-								class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase text-foreground-muted"
-								>SLK-482</span
-							>
-							<span
-								class="inline-flex items-center gap-1 text-[0.66rem] text-[var(--color-warning)]"
-							>
-								<span class="size-1.5 rounded-full bg-[var(--color-warning)]"></span>
-								In review
-							</span>
-						</div>
-						<p
-							class="m-0 text-[0.84rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-snug"
-						>
-							Refactor toolbar to share Button primitives
-						</p>
-					</div>
-				</ContextMenu.Trigger>
-				<ContextMenu.Content>
-					<ContextMenu.Item callback={() => {}}
-						><span class="flex items-center gap-2"><Pencil size={13} /> Edit task</span
-						></ContextMenu.Item
-					>
-					<ContextMenu.Item callback={() => {}}
-						><span class="flex items-center gap-2"><Star size={13} /> Watch</span></ContextMenu.Item
-					>
-					<ContextMenu.Item callback={() => {}}
-						><span class="flex items-center gap-2"><Share size={13} /> Share link</span
-						></ContextMenu.Item
-					>
-					<ContextMenu.Separator />
-					<ContextMenu.Item callback={() => {}}>Move to backlog</ContextMenu.Item>
-					<ContextMenu.Item callback={() => {}}>Close as complete</ContextMenu.Item>
-				</ContextMenu.Content>
-			</ContextMenu.Root>
-		</div>
-	</div>
-</section>
-
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>ContextMenu.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
+	<DocSection
+		icon={Sparkles}
+		title="Real-world examples"
+		description="Right-click any of these surfaces. Each one ships a different menu — that's the point."
 	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
+		<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+			<!-- File row -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
+				<span
+					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+				>
+					File row
+				</span>
+				<ContextMenu.Root>
+					<ContextMenu.Trigger>
+						<div
+							class="flex items-center gap-3 rounded-[var(--radius-md)] border border-dashed border-border bg-secondary/30 px-3 py-3 cursor-default"
+						>
+							<FileText size={14} class="text-foreground-muted" />
+							<div class="flex flex-col">
+								<span
+									class="text-[0.84rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)]"
+									>brand-guidelines.fig</span
+								>
+								<span class="text-[0.7rem] text-foreground-muted">Edited 2h ago · 4.2 MB</span>
+							</div>
+						</div>
+					</ContextMenu.Trigger>
+					<ContextMenu.Content>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><FolderOpen size={13} /> Open</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Pencil size={13} /> Rename</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Copy2 size={13} /> Duplicate</span>
+						</ContextMenu.Item>
+						<ContextMenu.Separator />
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Star size={13} /> Star</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Tag size={13} /> Add label</span>
+						</ContextMenu.Item>
+						<ContextMenu.Separator />
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2 text-[var(--color-destructive)]"
+								><Trash size={13} /> Move to trash</span
+							>
+						</ContextMenu.Item>
+					</ContextMenu.Content>
+				</ContextMenu.Root>
+			</div>
+
+			<!-- Image -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
+				<span
+					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+				>
+					Image
+				</span>
+				<ContextMenu.Root>
+					<ContextMenu.Trigger>
+						<div
+							class="grid h-24 place-items-center rounded-[var(--radius-md)] border border-border bg-[linear-gradient(135deg,color-mix(in_srgb,var(--color-primary)_30%,transparent),color-mix(in_srgb,var(--color-info)_30%,transparent))] cursor-default"
+						>
+							<Image size={20} class="text-foreground" />
+						</div>
+					</ContextMenu.Trigger>
+					<ContextMenu.Content>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Download size={13} /> Save image</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>
+							<span class="flex items-center gap-2"><Copy2 size={13} /> Copy image</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>Copy image address</ContextMenu.Item>
+						<ContextMenu.Separator />
+						<ContextMenu.Item callback={() => {}}>Open in new tab</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>Inspect</ContextMenu.Item>
+					</ContextMenu.Content>
+				</ContextMenu.Root>
+			</div>
+
+			<!-- Task card -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-4">
+				<span
+					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+				>
+					Task card
+				</span>
+				<ContextMenu.Root>
+					<ContextMenu.Trigger>
+						<div
+							class="flex flex-col gap-2 rounded-[var(--radius-md)] border border-border bg-background/40 p-3 cursor-default"
+						>
+							<div class="flex items-center justify-between gap-2">
+								<span
+									class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase text-foreground-muted"
+									>SLK-482</span
+								>
+								<span
+									class="inline-flex items-center gap-1 text-[0.66rem] text-[var(--color-warning)]"
+								>
+									<span class="size-1.5 rounded-full bg-[var(--color-warning)]"></span>
+									In review
+								</span>
+							</div>
+							<p
+								class="m-0 text-[0.84rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-snug"
+							>
+								Refactor toolbar to share Button primitives
+							</p>
+						</div>
+					</ContextMenu.Trigger>
+					<ContextMenu.Content>
+						<ContextMenu.Item callback={() => {}}
+							><span class="flex items-center gap-2"><Pencil size={13} /> Edit task</span
+							></ContextMenu.Item
+						>
+						<ContextMenu.Item callback={() => {}}
+							><span class="flex items-center gap-2"><Star size={13} /> Watch</span
+							></ContextMenu.Item
+						>
+						<ContextMenu.Item callback={() => {}}
+							><span class="flex items-center gap-2"><Share size={13} /> Share link</span
+							></ContextMenu.Item
+						>
+						<ContextMenu.Separator />
+						<ContextMenu.Item callback={() => {}}>Move to backlog</ContextMenu.Item>
+						<ContextMenu.Item callback={() => {}}>Close as complete</ContextMenu.Item>
+					</ContextMenu.Content>
+				</ContextMenu.Root>
+			</div>
 		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	</DocSection>
+
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="ContextMenu" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/dropdown-menu/+page.svelte
+++ b/apps/docs/src/routes/docs/components/dropdown-menu/+page.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as DropdownMenu from '@silk/ui/components/dropdown-menu';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import User from '@lucide/svelte/icons/user';
 	import Settings from '@lucide/svelte/icons/settings';
@@ -26,14 +21,14 @@
 	import Archive from '@lucide/svelte/icons/archive';
 	import EyeOff from '@lucide/svelte/icons/eye-off';
 	import Star from '@lucide/svelte/icons/star';
+	import Check from '@lucide/svelte/icons/check';
 	import LifeBuoy from '@lucide/svelte/icons/life-buoy';
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/dropdown-menu';
-
-	const curIndex = components.indexOf('dropdown-menu');
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const TITLE = 'Dropdown Menu';
+	const SLUG = 'dropdown-menu';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -86,18 +81,6 @@
 			description: 'Nested submenu -- opens on hover/click on the trigger.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add dropdown-menu';
 </script>
 
 <svelte:head>
@@ -105,60 +88,13 @@
 	<meta name="description" content="A floating menu of actions, anchored to a trigger." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Nestable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Dropdown Menu
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A list of actions anchored to a button. Use it for user menus, row-level actions, and anywhere
-			a `…` button needs to do more than one thing.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A list of actions anchored to a button. Use it for user menus, row-level actions, and anywhere a `…` button needs to do more than one thing."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Nestable' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -257,224 +193,145 @@
 	</div>
 </section>
 
-<!-- More realistic examples -->
-<section class="pt-12 flex flex-col gap-5">
-	<div class="flex flex-col gap-1">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-				<Sparkles size={12} />
-			</span>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Real-world examples
-			</h2>
-		</div>
-		<p class="m-0 text-[0.86rem] text-foreground-muted">
-			Three patterns from real product surfaces.
-		</p>
-	</div>
-
-	<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-		<!-- Row actions -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-			<div class="flex flex-col gap-1">
-				<span
-					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-				>
-					Row actions
-				</span>
-				<p class="m-0 text-[0.84rem] text-foreground-muted">The `…` button on a list item.</p>
-			</div>
-			<div class="grid place-items-center pt-4">
-				<DropdownMenu.Root class="" value="">
-					<DropdownMenu.Trigger variant="ghost" size="icon" class="size-8" aria-label="Row actions">
-						<MoreHorizontal size={14} />
-					</DropdownMenu.Trigger>
-					<DropdownMenu.Content class="min-w-[12rem]">
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><Pencil size={13} /> Rename</span
-							></DropdownMenu.Item
-						>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><Copy2 size={13} /> Duplicate</span><kbd
-								class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
-								>⌘D</kbd
-							></DropdownMenu.Item
-						>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><Archive size={13} /> Archive</span
-							></DropdownMenu.Item
-						>
-						<DropdownMenu.Separator class=""></DropdownMenu.Separator>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2 text-[var(--color-destructive)]"
-								><Trash size={13} /> Delete</span
-							><kbd
-								class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
-								>⌫</kbd
-							></DropdownMenu.Item
-						>
-					</DropdownMenu.Content>
-				</DropdownMenu.Root>
-			</div>
-		</div>
-
-		<!-- Share menu -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-			<div class="flex flex-col gap-1">
-				<span
-					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-				>
-					Share
-				</span>
-				<p class="m-0 text-[0.84rem] text-foreground-muted">Action button with grouped options.</p>
-			</div>
-			<div class="grid place-items-center pt-4">
-				<DropdownMenu.Root class="" value="">
-					<DropdownMenu.Trigger variant="outlined" class="h-9 gap-1.5 text-[0.82rem]">
-						<Send size={13} />
-						Share
-						<ChevronDown size={11} class="text-foreground-muted" />
-					</DropdownMenu.Trigger>
-					<DropdownMenu.Content class="min-w-[14rem]">
-						<DropdownMenu.Label class="">Workspace</DropdownMenu.Label>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><User size={13} /> Invite collaborator</span
-							></DropdownMenu.Item
-						>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><Copy2 size={13} /> Copy link</span><kbd
-								class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
-								>⇧⌘C</kbd
-							></DropdownMenu.Item
-						>
-						<DropdownMenu.Separator class=""></DropdownMenu.Separator>
-						<DropdownMenu.Label class="">Public</DropdownMenu.Label>
-						<DropdownMenu.Item class=""
-							><span class="flex items-center gap-2"><EyeOff size={13} /> Make private</span
-							></DropdownMenu.Item
-						>
-					</DropdownMenu.Content>
-				</DropdownMenu.Root>
-			</div>
-		</div>
-
-		<!-- Sort -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-			<div class="flex flex-col gap-1">
-				<span
-					class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
-				>
-					Sort
-				</span>
-				<p class="m-0 text-[0.84rem] text-foreground-muted">
-					Compact menu with the active choice indicated.
-				</p>
-			</div>
-			<div class="grid place-items-center pt-4">
-				<DropdownMenu.Root class="" value="">
-					<DropdownMenu.Trigger variant="ghost" class="h-9 gap-1.5 text-[0.82rem]">
-						<Star size={13} />
-						Most starred
-						<ChevronDown size={11} class="text-foreground-muted" />
-					</DropdownMenu.Trigger>
-					<DropdownMenu.Content class="min-w-[12rem]">
-						<DropdownMenu.Item class=""
-							><span>Most starred</span><Check size={12} class="text-primary" /></DropdownMenu.Item
-						>
-						<DropdownMenu.Item class=""><span>Recently updated</span></DropdownMenu.Item>
-						<DropdownMenu.Item class=""><span>Alphabetical</span></DropdownMenu.Item>
-						<DropdownMenu.Item class=""><span>Oldest first</span></DropdownMenu.Item>
-					</DropdownMenu.Content>
-				</DropdownMenu.Root>
-			</div>
-		</div>
-	</div>
-</section>
-
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>DropdownMenu.{row.component}</code
-							>
-							<code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
+	<DocSection
+		icon={Sparkles}
+		title="Real-world examples"
+		description="Three patterns from real product surfaces."
 	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
+		<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+			<!-- Row actions -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
+				<div class="flex flex-col gap-1">
+					<span
+						class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+					>
+						Row actions
+					</span>
+					<p class="m-0 text-[0.84rem] text-foreground-muted">The `…` button on a list item.</p>
+				</div>
+				<div class="grid place-items-center pt-4">
+					<DropdownMenu.Root class="" value="">
+						<DropdownMenu.Trigger
+							variant="ghost"
+							size="icon"
+							class="size-8"
+							aria-label="Row actions"
+						>
+							<MoreHorizontal size={14} />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content class="min-w-[12rem]">
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><Pencil size={13} /> Rename</span
+								></DropdownMenu.Item
+							>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><Copy2 size={13} /> Duplicate</span><kbd
+									class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
+									>⌘D</kbd
+								></DropdownMenu.Item
+							>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><Archive size={13} /> Archive</span
+								></DropdownMenu.Item
+							>
+							<DropdownMenu.Separator class=""></DropdownMenu.Separator>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2 text-[var(--color-destructive)]"
+									><Trash size={13} /> Delete</span
+								><kbd
+									class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
+									>⌫</kbd
+								></DropdownMenu.Item
+							>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+				</div>
+			</div>
+
+			<!-- Share menu -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
+				<div class="flex flex-col gap-1">
+					<span
+						class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+					>
+						Share
+					</span>
+					<p class="m-0 text-[0.84rem] text-foreground-muted">
+						Action button with grouped options.
+					</p>
+				</div>
+				<div class="grid place-items-center pt-4">
+					<DropdownMenu.Root class="" value="">
+						<DropdownMenu.Trigger variant="outlined" class="h-9 gap-1.5 text-[0.82rem]">
+							<Send size={13} />
+							Share
+							<ChevronDown size={11} class="text-foreground-muted" />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content class="min-w-[14rem]">
+							<DropdownMenu.Label class="">Workspace</DropdownMenu.Label>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><User size={13} /> Invite collaborator</span
+								></DropdownMenu.Item
+							>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><Copy2 size={13} /> Copy link</span><kbd
+									class="rounded border border-border bg-secondary/60 px-1.5 py-0.5 font-mono text-[0.62rem] text-foreground-muted"
+									>⇧⌘C</kbd
+								></DropdownMenu.Item
+							>
+							<DropdownMenu.Separator class=""></DropdownMenu.Separator>
+							<DropdownMenu.Label class="">Public</DropdownMenu.Label>
+							<DropdownMenu.Item class=""
+								><span class="flex items-center gap-2"><EyeOff size={13} /> Make private</span
+								></DropdownMenu.Item
+							>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+				</div>
+			</div>
+
+			<!-- Sort -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
+				<div class="flex flex-col gap-1">
+					<span
+						class="text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] uppercase tracking-wide text-foreground-muted"
+					>
+						Sort
+					</span>
+					<p class="m-0 text-[0.84rem] text-foreground-muted">
+						Compact menu with the active choice indicated.
+					</p>
+				</div>
+				<div class="grid place-items-center pt-4">
+					<DropdownMenu.Root class="" value="">
+						<DropdownMenu.Trigger variant="ghost" class="h-9 gap-1.5 text-[0.82rem]">
+							<Star size={13} />
+							Most starred
+							<ChevronDown size={11} class="text-foreground-muted" />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content class="min-w-[12rem]">
+							<DropdownMenu.Item class=""
+								><span>Most starred</span><Check
+									size={12}
+									class="text-primary"
+								/></DropdownMenu.Item
+							>
+							<DropdownMenu.Item class=""><span>Recently updated</span></DropdownMenu.Item>
+							<DropdownMenu.Item class=""><span>Alphabetical</span></DropdownMenu.Item>
+							<DropdownMenu.Item class=""><span>Oldest first</span></DropdownMenu.Item>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+				</div>
+			</div>
 		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	</DocSection>
+
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="DropdownMenu" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/hover-card/+page.svelte
+++ b/apps/docs/src/routes/docs/components/hover-card/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as HoverCard from '@silk/ui/components/hover-card';
 	import * as Avatar from '@silk/ui/components/avatar';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Hover Card';
 	const SLUG = 'hover-card';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -51,17 +44,6 @@
 			description: 'Floating-UI placement.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -71,54 +53,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Hover + Focus triggered</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A preview card that opens on hover or keyboard focus. Use it for user mentions, link previews,
-			or definitions.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A preview card that opens on hover or keyboard focus. Use it for user mentions, link previews, or definitions."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Hover + Focus triggered' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -168,83 +109,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>HoverCard.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="HoverCard" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/input/+page.svelte
+++ b/apps/docs/src/routes/docs/components/input/+page.svelte
@@ -1,26 +1,22 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { Input } from '@silk/ui/components/input';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Layers from '@lucide/svelte/icons/layers-3';
 
 	const TITLE = 'Input';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/input';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'input';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	type Variant = 'primary' | 'secondary' | 'outlined';
 	let pgVariant = $state<Variant>('outlined');
@@ -86,17 +82,7 @@
   bind:value
 />`);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add input';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
@@ -107,60 +93,13 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">3 variants</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Input
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			The workhorse of every form. Three variants for different surface densities; bindable value
-			and full passthrough to the underlying `&lt;input&gt;`.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="The workhorse of every form. Three variants for different surface densities; bindable value and full passthrough to the underlying `<input>`."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: '3 variants' }]}
+/>
 
 <!-- Playground -->
 <section class="pt-10">
@@ -237,10 +176,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}<Check
+					{#if clip.copied('playground')}<Check
 							size={11}
 							class="text-[var(--color-success)]"
 						/>Copied{:else}<Copy size={11} />Copy code{/if}
@@ -255,22 +194,7 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<!-- VARIANTS -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-					><Layers size={12} /></span
-				>
-				<h2
-					class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					Variants
-				</h2>
-			</div>
-		</div>
-
+	<DocSection icon={Layers} title="Variants">
 		<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
 			{#each variantList as v}
 				<div
@@ -281,84 +205,13 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+	</DocSection>
 
-	<!-- API -->
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/label/+page.svelte
+++ b/apps/docs/src/routes/docs/components/label/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Label } from '@silk/ui/components/label';
 	import { Input } from '@silk/ui/components/input';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Label';
 	const SLUG = 'label';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -35,17 +28,6 @@
 			description: 'Spread onto the underlying <label>.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -55,54 +37,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Form primitive</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A theme-aware form label that pairs with any input, fades correctly when the field is disabled
-			via <code class="font-mono text-[0.82rem]">peer-disabled</code>.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A theme-aware form label that pairs with any input, fades correctly when the field is disabled via peer-disabled."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Form primitive' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -133,81 +74,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/marquee/+page.svelte
+++ b/apps/docs/src/routes/docs/components/marquee/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Marquee } from '@silk/ui/components/marquee';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Marquee';
 	const SLUG = 'marquee';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -64,17 +57,6 @@
 		'GitHub',
 		'Notion'
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -84,54 +66,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Magic UI inspiration</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A CSS-only infinite scroll. Pure transforms, no JavaScript timeline — pauses on hover when you
-			want it to.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A CSS-only infinite scroll. Pure transforms, no JavaScript timeline — pauses on hover when you want it to."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Magic UI inspiration' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -175,81 +116,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/modal/+page.svelte
+++ b/apps/docs/src/routes/docs/components/modal/+page.svelte
@@ -1,25 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Modal from '@silk/ui/components/modal';
-	import { components, sanitizeComponent } from '$lib/components';
-
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Modal';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/modal';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'modal';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -72,18 +64,6 @@
 			description: 'Fires action then closes.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add modal';
 </script>
 
 <svelte:head>
@@ -94,61 +74,13 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Primitive</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Modal
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			The low-level overlay primitive used by Dialog, AlertDialog, and the publish/admin flows. You
-			probably want one of those — reach for Modal directly only when you need a custom surface
-			shape.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="The low-level overlay primitive used by Dialog, AlertDialog, and the publish/admin flows. You probably want one of those — reach for Modal directly only when you need a custom surface shape."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Primitive' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -201,85 +133,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Modal" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Modal.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/pagination/+page.svelte
+++ b/apps/docs/src/routes/docs/components/pagination/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Pagination } from '@silk/ui/components/pagination';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Pagination';
 	const SLUG = 'pagination';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -43,17 +36,6 @@
 	];
 
 	let page = $state(4);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -63,54 +45,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Ellipsis truncation</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A compact pager that truncates with an ellipsis. Always shows the first and last page so users
-			know how big the data set is.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A compact pager that truncates with an ellipsis. Always shows the first and last page so users know how big the data set is."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Ellipsis truncation' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -134,81 +75,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/popover/+page.svelte
+++ b/apps/docs/src/routes/docs/components/popover/+page.svelte
@@ -1,26 +1,20 @@
 <script lang="ts">
 	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Popover from '@silk/ui/components/popover';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Bell from '@lucide/svelte/icons/bell';
 
 	const TITLE = 'Popover';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/popover';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'popover';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -52,18 +46,6 @@
 			description: 'Wraps the inner panel -- set width with `w-[N]`.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add popover';
 </script>
 
 <svelte:head>
@@ -71,60 +53,13 @@
 	<meta name="description" content="A floating surface anchored to a trigger element." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Floating UI</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Popover
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			The primitive behind every floating menu in Silk. Pair a trigger with an anchored surface that
-			handles outside-click, escape, focus, and collision-aware placement for you.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="The primitive behind every floating menu in Silk. Pair a trigger with an anchored surface that handles outside-click, escape, focus, and collision-aware placement for you."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Floating UI' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -177,85 +112,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Popover" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Popover.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/progress/+page.svelte
+++ b/apps/docs/src/routes/docs/components/progress/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Progress } from '@silk/ui/components/progress';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import { onMount } from 'svelte';
 
 	const TITLE = 'Progress';
 	const SLUG = 'progress';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -44,17 +37,6 @@
 		}, 600);
 		return () => clearInterval(id);
 	});
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -64,54 +46,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Determinate + Indeterminate</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Show how far along a task is. Skip the value to show a looping indicator for tasks of unknown
-			duration.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Show how far along a task is. Skip the value to show a looping indicator for tasks of unknown duration."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Determinate + Indeterminate' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -148,81 +89,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/radio-group/+page.svelte
+++ b/apps/docs/src/routes/docs/components/radio-group/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as RadioGroup from '@silk/ui/components/radio-group';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Radio Group';
 	const SLUG = 'radio-group';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -66,17 +59,6 @@
 	];
 
 	let plan = $state<string | undefined>('pro');
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -86,53 +68,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Native radio underneath</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A themed wrapper around the native radio input. Works inside any form with no extra wiring.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A themed wrapper around the native radio input. Works inside any form with no extra wiring."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Native radio underneath' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -174,83 +116,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>RadioGroup.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="RadioGroup" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/scroll-area/+page.svelte
+++ b/apps/docs/src/routes/docs/components/scroll-area/+page.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { ScrollArea } from '@silk/ui/components/scroll-area';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Scroll Area';
 	const SLUG = 'scroll-area';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -30,17 +23,6 @@
 	];
 
 	const items = Array.from({ length: 24 }, (_, i) => `Item ${i + 1}`);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -50,54 +32,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Themed scrollbar</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A scroll container that styles its scrollbar to match the theme. Pure CSS, no shadow DOM, no
-			measurement loops.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A scroll container that styles its scrollbar to match the theme. Pure CSS, no shadow DOM, no measurement loops."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Themed scrollbar' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -139,81 +80,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">ScrollArea</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/select/+page.svelte
+++ b/apps/docs/src/routes/docs/components/select/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Select from '@silk/ui/components/select';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Select';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/select';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'select';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgRole = $state('designer');
 
@@ -67,18 +60,6 @@
 			description: 'Non-interactive group heading.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add select';
 </script>
 
 <svelte:head>
@@ -86,60 +67,13 @@
 	<meta name="description" content="Single-choice dropdown for short, known option lists." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Bindable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Select
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A controlled dropdown for short option lists. Once the list goes past ~10 items, switch to
-			Combobox so users can type to filter.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A controlled dropdown for short option lists. Once the list goes past ~10 items, switch to Combobox so users can type to filter."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Bindable' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -186,85 +120,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Select" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Select.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/separator/+page.svelte
+++ b/apps/docs/src/routes/docs/components/separator/+page.svelte
@@ -1,26 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Separator } from '@silk/ui/components/separator';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Separator';
 	const SLUG = 'separator';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -36,18 +28,6 @@
 			description: 'When false, the divider is announced to assistive tech as a real separator.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head>
@@ -55,57 +35,13 @@
 	<meta name="description" content="A visual or semantic rule between content." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Horizontal + Vertical</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A 1px rule for splitting groups of content. Defaults to horizontal but flips to vertical with
-			one prop.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A 1px rule for splitting groups of content. Defaults to horizontal but flips to vertical with one prop."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Horizontal + Vertical' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -144,81 +80,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/sheet/+page.svelte
+++ b/apps/docs/src/routes/docs/components/sheet/+page.svelte
@@ -1,26 +1,20 @@
 <script lang="ts">
 	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Sheet from '@silk/ui/components/sheet';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Menu from '@lucide/svelte/icons/menu';
 
 	const TITLE = 'Sheet';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/sheet';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'sheet';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -66,18 +60,6 @@
 			description: 'Closes the sheet on click.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add sheet';
 </script>
 
 <svelte:head>
@@ -88,60 +70,13 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Left + Right</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Sheet
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A modal drawer that slides in from the side. Use it for mobile navigation, filter panels, and
-			anything that wants the full height of the viewport without being a full Dialog.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A modal drawer that slides in from the side. Use it for mobile navigation, filter panels, and anything that wants the full height of the viewport without being a full Dialog."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Left + Right' }]}
+/>
 
 <!-- Preview -->
 <section class="pt-10">
@@ -208,85 +143,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Sheet" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Sheet.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/shortcut/+page.svelte
+++ b/apps/docs/src/routes/docs/components/shortcut/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import Shortcut from '@silk/ui/components/shortcut';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Shortcut';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/shortcut';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'shortcut';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -35,18 +28,6 @@
 			description: 'Optional override display content (defaults to the shortcut text).'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add shortcut';
 </script>
 
 <svelte:head>
@@ -54,60 +35,13 @@
 	<meta name="description" content="Inline keyboard-shortcut badge." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Inline</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Shortcut
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A small `kbd`-style badge for surfacing keyboard shortcuts inside buttons, menu items, and
-			command triggers.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A small `kbd`-style badge for surfacing keyboard shortcuts inside buttons, menu items, and command triggers."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Inline' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -139,81 +73,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/skeleton/+page.svelte
+++ b/apps/docs/src/routes/docs/components/skeleton/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { Skeleton } from '@silk/ui/components/skeleton';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Skeleton';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/skeleton';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'skeleton';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{ prop: 'w', type: 'number', default: '--', description: 'Width value (paired with `unit`).' },
@@ -37,18 +30,6 @@
 			description: 'Tailwind classes for shape -- e.g. `rounded-full`.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add skeleton';
 </script>
 
 <svelte:head>
@@ -56,59 +37,13 @@
 	<meta name="description" content="Shimmering placeholder for loading content." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Skeleton
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A neutral placeholder rectangle for content that's still loading. Compose any shape by passing
-			Tailwind sizing classes — Skeleton itself has no opinions about dimensions.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A neutral placeholder rectangle for content that's still loading. Compose any shape by passing Tailwind sizing classes — Skeleton itself has no opinions about dimensions."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -149,81 +84,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/slider/+page.svelte
+++ b/apps/docs/src/routes/docs/components/slider/+page.svelte
@@ -1,24 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Slider } from '@silk/ui/components/slider';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
+
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Slider';
 	const SLUG = 'slider';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{ prop: 'value', type: 'number', default: '0', description: 'Bindable current value.' },
@@ -46,17 +40,6 @@
 	];
 
 	let volume = $state(64);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -66,54 +49,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Themed range</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A themed wrapper around the native range input. Keyboard-driven for free, drag-to-set on every
-			device.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A themed wrapper around the native range input. Keyboard-driven for free, drag-to-set on every device."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Themed range' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -144,81 +86,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/switch/+page.svelte
+++ b/apps/docs/src/routes/docs/components/switch/+page.svelte
@@ -1,25 +1,21 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { Switch } from '@silk/ui/components/switch';
-	import { components, sanitizeComponent } from '$lib/components';
+	import { createCopy } from '$lib/copy.svelte';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Switch';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/switch';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'switch';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgOn = $state(true);
 	let pgLabel = $state('Push notifications');
@@ -57,17 +53,7 @@
 		`<Switch bind:switched={value} label="${pgLabel}" description="${pgDesc}" />`
 	);
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add switch';
+	const clip = createCopy();
 </script>
 
 <svelte:head>
@@ -75,60 +61,13 @@
 	<meta name="description" content="On/off toggle for system-level settings." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Bindable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Switch
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A toggle for things that take effect immediately — notifications, dark mode, auto-save. Pair
-			it with a clear label so users know what they're enabling.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A toggle for things that take effect immediately — notifications, dark mode, auto-save. Pair it with a clear label so users know what they're enabling."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Bindable' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -180,10 +119,10 @@
 				>
 				<button
 					type="button"
-					onclick={() => copy(playgroundCode, 'playground')}
+					onclick={() => clip.copy(playgroundCode, 'playground')}
 					class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-[0.72rem] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
 				>
-					{#if copiedSnippet === 'playground'}<Check
+					{#if clip.copied('playground')}<Check
 							size={11}
 							class="text-[var(--color-success)]"
 						/>Copied{:else}<Copy size={11} />Copy code{/if}
@@ -198,81 +137,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/tabs/+page.svelte
+++ b/apps/docs/src/routes/docs/components/tabs/+page.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Tabs from '@silk/ui/components/tabs';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 	import TrendingUp from '@lucide/svelte/icons/trending-up';
 	import Users from '@lucide/svelte/icons/users';
@@ -24,11 +19,9 @@
 	let projectTab = $state('overview');
 
 	const TITLE = 'Tabs';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/tabs';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'tabs';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgTab = $state('overview');
 
@@ -69,18 +62,6 @@
 			description: 'The panel shown when this value matches Root.value.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add tabs';
 </script>
 
 <svelte:head>
@@ -91,60 +72,13 @@
 	/>
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Sliding indicator</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Tabs
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A peer-level switcher for views that share a context. The sliding indicator's speed comes from
-			your theme's motion preset — change the preset, the tabs follow.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A peer-level switcher for views that share a context. The sliding indicator's speed comes from your theme's motion preset — change the preset, the tabs follow."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Sliding indicator' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -189,228 +123,141 @@
 	</div>
 </section>
 
-<!-- Real-world examples -->
-<section class="pt-12 flex flex-col gap-5">
-	<div class="flex flex-col gap-1">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary">
-				<Sparkles size={12} />
-			</span>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Real-world examples
-			</h2>
-		</div>
-		<p class="m-0 text-[0.86rem] text-foreground-muted">
-			Three patterns where Tabs earn their keep.
-		</p>
-	</div>
-
-	<!-- Project tabs -->
-	<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-		<div class="flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-start">
-			<div>
-				<p
-					class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
-				>
-					Project activity
-				</p>
-				<p
-					class="m-0 mt-0.5 text-[1.05rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					silk-ui / dashboard
-				</p>
-			</div>
-			<Tabs.Root bind:value={projectTab}>
-				<Tabs.List>
-					<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
-					<Tabs.Trigger value="activity">Activity</Tabs.Trigger>
-					<Tabs.Trigger value="files">Files</Tabs.Trigger>
-				</Tabs.List>
-			</Tabs.Root>
-		</div>
-		<div class="text-[0.86rem] text-foreground-muted">
-			{#if projectTab === 'overview'}
-				<div class="grid grid-cols-3 gap-3 max-sm:grid-cols-1">
-					{#each [{ label: 'Open issues', value: '23', tone: 'text-[var(--color-warning)]' }, { label: 'Merged this week', value: '47', tone: 'text-[var(--color-success)]' }, { label: 'Build status', value: 'Passing', tone: 'text-[var(--color-success)]' }] as stat}
-						<div class="rounded-[var(--radius-md)] border border-border bg-background/40 p-3">
-							<p class="m-0 text-[0.7rem] text-foreground-muted">{stat.label}</p>
-							<p
-								class="m-0 mt-1 text-[1.4rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)] tracking-tight {stat.tone}"
-							>
-								{stat.value}
-							</p>
-						</div>
-					{/each}
-				</div>
-			{:else if projectTab === 'activity'}
-				<div class="flex flex-col gap-2">
-					{#each [{ who: 'Maya Chen', what: 'merged main into release-2.5', when: '2m' }, { who: 'Aidan Neel', what: 'opened PR #482 · refactor toolbar', when: '14m' }, { who: 'Leo Park', what: 'commented on issue #311', when: '1h' }, { who: 'GitHub Actions', what: 'deployed v2.4.1 to production', when: '3h' }] as item}
-						<div class="flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-secondary/40">
-							<TrendingUp size={13} class="text-foreground-muted" />
-							<span class="text-foreground">{item.who}</span>
-							<span class="text-foreground-muted">{item.what}</span>
-							<span class="ml-auto text-[0.72rem] text-foreground-muted/70">{item.when}</span>
-						</div>
-					{/each}
-				</div>
-			{:else}
-				<div class="flex flex-col gap-2">
-					{#each [{ name: 'silk-ui-roadmap.md', size: '12 KB' }, { name: 'design-tokens.json', size: '4.8 KB' }, { name: 'brand-guidelines.fig', size: '4.2 MB' }, { name: 'icons.svg', size: '88 KB' }] as file}
-						<div class="flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-secondary/40">
-							<FileText size={13} class="text-foreground-muted" />
-							<span class="text-foreground">{file.name}</span>
-							<span class="ml-auto text-[0.72rem] text-foreground-muted/70">{file.size}</span>
-						</div>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	</div>
-
-	<!-- Billing period -->
-	<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+<div class="flex flex-col gap-16 pt-16">
+	<DocSection
+		icon={Sparkles}
+		title="Real-world examples"
+		description="Three patterns where Tabs earn their keep."
+	>
+		<!-- Project tabs -->
 		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-			<p
-				class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
-			>
-				Billing period
-			</p>
-			<Tabs.Root bind:value={billingPeriod}>
-				<Tabs.List>
-					<Tabs.Trigger value="monthly">Monthly</Tabs.Trigger>
-					<Tabs.Trigger value="annual">Annual (-20%)</Tabs.Trigger>
-				</Tabs.List>
-			</Tabs.Root>
-			<div class="flex items-baseline gap-1.5">
-				<span
-					class="text-[2.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-					style="font-family: var(--font-header);"
-				>
-					{billingPeriod === 'monthly' ? '$24' : '$19'}
-				</span>
-				<span class="text-[0.86rem] text-foreground-muted">/seat/month</span>
+			<div class="flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-start">
+				<div>
+					<p
+						class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
+					>
+						Project activity
+					</p>
+					<p
+						class="m-0 mt-0.5 text-[1.05rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
+						style="font-family: var(--font-header);"
+					>
+						silk-ui / dashboard
+					</p>
+				</div>
+				<Tabs.Root bind:value={projectTab}>
+					<Tabs.List>
+						<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+						<Tabs.Trigger value="activity">Activity</Tabs.Trigger>
+						<Tabs.Trigger value="files">Files</Tabs.Trigger>
+					</Tabs.List>
+				</Tabs.Root>
 			</div>
-			<p class="m-0 text-[0.8rem] text-foreground-muted">
-				{billingPeriod === 'monthly'
-					? 'Billed monthly. Cancel anytime.'
-					: 'Billed annually. Save $60 per seat per year.'}
-			</p>
-		</div>
-
-		<!-- Settings -->
-		<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
-			<p
-				class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
-			>
-				Settings
-			</p>
-			<Tabs.Root bind:value={settingsTab}>
-				<Tabs.List>
-					<Tabs.Trigger value="general">General</Tabs.Trigger>
-					<Tabs.Trigger value="members">Members</Tabs.Trigger>
-					<Tabs.Trigger value="api">API</Tabs.Trigger>
-				</Tabs.List>
-			</Tabs.Root>
-			<div class="text-[0.84rem] text-foreground-muted">
-				{#if settingsTab === 'general'}
-					Workspace name, time zone, default language. Most teams set this once and forget.
-				{:else if settingsTab === 'members'}
-					<div class="flex items-center gap-2">
-						<Users size={13} />
-						<span>12 members · 3 admins</span>
-						<BadgeComp variant="ghost" class="ml-auto text-[0.66rem]">2 pending</BadgeComp>
+			<div class="text-[0.86rem] text-foreground-muted">
+				{#if projectTab === 'overview'}
+					<div class="grid grid-cols-3 gap-3 max-sm:grid-cols-1">
+						{#each [{ label: 'Open issues', value: '23', tone: 'text-[var(--color-warning)]' }, { label: 'Merged this week', value: '47', tone: 'text-[var(--color-success)]' }, { label: 'Build status', value: 'Passing', tone: 'text-[var(--color-success)]' }] as stat}
+							<div class="rounded-[var(--radius-md)] border border-border bg-background/40 p-3">
+								<p class="m-0 text-[0.7rem] text-foreground-muted">{stat.label}</p>
+								<p
+									class="m-0 mt-1 text-[1.4rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)] tracking-tight {stat.tone}"
+								>
+									{stat.value}
+								</p>
+							</div>
+						{/each}
+					</div>
+				{:else if projectTab === 'activity'}
+					<div class="flex flex-col gap-2">
+						{#each [{ who: 'Maya Chen', what: 'merged main into release-2.5', when: '2m' }, { who: 'Aidan Neel', what: 'opened PR #482 · refactor toolbar', when: '14m' }, { who: 'Leo Park', what: 'commented on issue #311', when: '1h' }, { who: 'GitHub Actions', what: 'deployed v2.4.1 to production', when: '3h' }] as item}
+							<div class="flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-secondary/40">
+								<TrendingUp size={13} class="text-foreground-muted" />
+								<span class="text-foreground">{item.who}</span>
+								<span class="text-foreground-muted">{item.what}</span>
+								<span class="ml-auto text-[0.72rem] text-foreground-muted/70">{item.when}</span>
+							</div>
+						{/each}
 					</div>
 				{:else}
-					Generate API keys, configure webhooks, rotate the signing secret.
+					<div class="flex flex-col gap-2">
+						{#each [{ name: 'silk-ui-roadmap.md', size: '12 KB' }, { name: 'design-tokens.json', size: '4.8 KB' }, { name: 'brand-guidelines.fig', size: '4.2 MB' }, { name: 'icons.svg', size: '88 KB' }] as file}
+							<div class="flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-secondary/40">
+								<FileText size={13} class="text-foreground-muted" />
+								<span class="text-foreground">{file.name}</span>
+								<span class="ml-auto text-[0.72rem] text-foreground-muted/70">{file.size}</span>
+							</div>
+						{/each}
+					</div>
 				{/if}
 			</div>
 		</div>
-	</div>
-</section>
 
-<div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+		<!-- Billing period -->
+		<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
+				<p
+					class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
+				>
+					Billing period
+				</p>
+				<Tabs.Root bind:value={billingPeriod}>
+					<Tabs.List>
+						<Tabs.Trigger value="monthly">Monthly</Tabs.Trigger>
+						<Tabs.Trigger value="annual">Annual (-20%)</Tabs.Trigger>
+					</Tabs.List>
+				</Tabs.Root>
+				<div class="flex items-baseline gap-1.5">
+					<span
+						class="text-[2.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
+						style="font-family: var(--font-header);"
+					>
+						{billingPeriod === 'monthly' ? '$24' : '$19'}
+					</span>
+					<span class="text-[0.86rem] text-foreground-muted">/seat/month</span>
+				</div>
+				<p class="m-0 text-[0.8rem] text-foreground-muted">
+					{billingPeriod === 'monthly'
+						? 'Billed monthly. Cancel anytime.'
+						: 'Billed annually. Save $60 per seat per year.'}
+				</p>
+			</div>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">Tabs.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
+			<!-- Settings -->
+			<div class="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-border bg-card p-5">
+				<p
+					class="m-0 text-[0.78rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted"
+				>
+					Settings
+				</p>
+				<Tabs.Root bind:value={settingsTab}>
+					<Tabs.List>
+						<Tabs.Trigger value="general">General</Tabs.Trigger>
+						<Tabs.Trigger value="members">Members</Tabs.Trigger>
+						<Tabs.Trigger value="api">API</Tabs.Trigger>
+					</Tabs.List>
+				</Tabs.Root>
+				<div class="text-[0.84rem] text-foreground-muted">
+					{#if settingsTab === 'general'}
+						Workspace name, time zone, default language. Most teams set this once and forget.
+					{:else if settingsTab === 'members'}
+						<div class="flex items-center gap-2">
+							<Users size={13} />
+							<span>12 members · 3 admins</span>
+							<BadgeComp variant="ghost" class="ml-auto text-[0.66rem]">2 pending</BadgeComp>
 						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
+					{:else}
+						Generate API keys, configure webhooks, rotate the signing secret.
+					{/if}
+				</div>
+			</div>
 		</div>
-	</section>
+	</DocSection>
 
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Tabs" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/textarea/+page.svelte
+++ b/apps/docs/src/routes/docs/components/textarea/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { Textarea } from '@silk/ui/components/textarea';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Textarea';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/textarea';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'textarea';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	let pgValue = $state(
 		"Silk's textarea uses the same field tokens as Input -- labels, descriptions, and focus rings stay consistent."
@@ -49,18 +42,6 @@
 		{ prop: 'disabled', type: 'boolean', default: 'false', description: 'Standard disabled.' },
 		{ prop: 'class', type: 'string', default: '--', description: 'Classes for the inner textarea.' }
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add textarea';
 </script>
 
 <svelte:head>
@@ -68,60 +49,13 @@
 	<meta name="description" content="Multi-line text input that shares Input's grammar." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Bindable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Textarea
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Multi-line counterpart to Input. Same focus ring, same label structure — pick this any time
-			you expect more than one line of content.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Multi-line counterpart to Input. Same focus ring, same label structure — pick this any time you expect more than one line of content."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Bindable' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -158,81 +92,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/toast/+page.svelte
+++ b/apps/docs/src/routes/docs/components/toast/+page.svelte
@@ -1,25 +1,19 @@
 <script lang="ts">
 	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import { toast } from '@silk/ui/components/toast';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 
 	const TITLE = 'Toast';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/toast';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'toast';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{ prop: 'title', type: 'string', default: '--', description: 'Required headline.' },
@@ -44,18 +38,6 @@
 		}
 	];
 
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add toast';
-
 	function fakeUpload(): Promise<string> {
 		return new Promise((resolve) => setTimeout(() => resolve('avatar.png'), 1400));
 	}
@@ -66,60 +48,13 @@
 	<meta name="description" content="Transient notifications fired from anywhere in your app." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Imperative API</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Toast
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			Fire a notification from anywhere — click handlers, server responses, async flows. Toasts
-			stack, auto-dismiss, and can carry actions if recovery is one click away.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="Fire a notification from anywhere — click handlers, server responses, async flows. Toasts stack, auto-dismiss, and can carry actions if recovery is one click away."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Imperative API' }]}
+/>
 
 <!-- Playground -->
 <section class="pt-10">
@@ -191,81 +126,11 @@ toast.promise(uploadFile(), {
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.6fr_0.5fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<code
-							class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-							>{row.prop}</code
-						>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/toggle-group/+page.svelte
+++ b/apps/docs/src/routes/docs/components/toggle-group/+page.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import * as ToggleGroup from '@silk/ui/components/toggle-group';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import AlignLeft from '@lucide/svelte/icons/align-left';
 	import AlignCenter from '@lucide/svelte/icons/align-center';
 	import AlignRight from '@lucide/svelte/icons/align-right';
@@ -19,9 +14,7 @@
 	const TITLE = 'Toggle Group';
 	const SLUG = 'toggle-group';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -55,17 +48,6 @@
 	];
 
 	let alignment = $state<string | string[] | undefined>('center');
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -75,54 +57,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Single + Multiple</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A group of toggles that share state. Use single mode for radio-like exclusivity, multiple for
-			independent selections.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A group of toggles that share state. Use single mode for radio-like exclusivity, multiple for independent selections."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Single + Multiple' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -163,83 +104,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>ToggleGroup.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="ToggleGroup" />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/toggle/+page.svelte
+++ b/apps/docs/src/routes/docs/components/toggle/+page.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
-	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { Toggle } from '@silk/ui/components/toggle';
 	import { highlight } from '$lib/highlight';
-	import { components, sanitizeComponent } from '$lib/components';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Bold from '@lucide/svelte/icons/bold';
 	import Italic from '@lucide/svelte/icons/italic';
 	import Underline from '@lucide/svelte/icons/underline';
@@ -19,9 +14,7 @@
 	const TITLE = 'Toggle';
 	const SLUG = 'toggle';
 	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
-	const curIndex = components.indexOf(SLUG);
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -54,17 +47,6 @@
 	let bold = $state(true);
 	let italic = $state(false);
 	let underline = $state(false);
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 </script>
 
 <svelte:head
@@ -74,54 +56,13 @@
 	/></svelte:head
 >
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="ghost" class="text-[0.66rem]">Pressable</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-			>View source<External size={11} /></a
-		>
-	</div>
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			{TITLE}
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A pressable button with an explicit on/off state. Pair multiples in a Toggle Group for
-			radio-like or multi-select behavior.
-		</p>
-	</div>
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-			>{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}</button
-		>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A pressable button with an explicit on/off state. Pair multiples in a Toggle Group for radio-like or multi-select behavior."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'Pressable' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -152,81 +93,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted">{TITLE}</code><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} />
+	</DocSection>
+
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />

--- a/apps/docs/src/routes/docs/components/tooltip/+page.svelte
+++ b/apps/docs/src/routes/docs/components/tooltip/+page.svelte
@@ -1,26 +1,20 @@
 <script lang="ts">
 	import { Button } from '@silk/ui/components/button';
-	import { Badge } from '@silk/ui/components/badge';
 	import { highlight } from '$lib/highlight';
 	import * as Tooltip from '@silk/ui/components/tooltip';
-	import { components, sanitizeComponent } from '$lib/components';
+	import DocHeader from '$lib/components/docs/doc-header.svelte';
+	import DocSection from '$lib/components/docs/doc-section.svelte';
+	import PropTable from '$lib/components/docs/prop-table.svelte';
+	import DocFooter from '$lib/components/docs/doc-footer.svelte';
+	import DocPager from '$lib/components/docs/doc-pager.svelte';
 
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import Copy from '@lucide/svelte/icons/copy';
-	import Check from '@lucide/svelte/icons/check';
-	import Component from '@lucide/svelte/icons/component';
 	import Hash from '@lucide/svelte/icons/hash';
-	import External from '@lucide/svelte/icons/external-link';
 	import Info from '@lucide/svelte/icons/info';
 
 	const TITLE = 'Tooltip';
-	const SOURCE = 'https://github.com/aidan-neel/silk/tree/main/registry/silk/default/tooltip';
-
-	const curIndex = components.indexOf(TITLE.toLowerCase());
-	const prevComponent = components[curIndex - 1];
-	const nextComponent = components[curIndex + 1];
+	const SLUG = 'tooltip';
+	const SOURCE = `https://github.com/aidan-neel/silk/tree/main/registry/silk/default/${SLUG}`;
+	const installCommand = `bunx @aidan-neel/ui add ${SLUG}`;
 
 	const apiRows = [
 		{
@@ -60,18 +54,6 @@
 			description: 'Tooltip body -- keep it to a sentence.'
 		}
 	];
-
-	let copiedSnippet = $state<string | null>(null);
-	function copy(text: string, key: string) {
-		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-		void navigator.clipboard.writeText(text);
-		copiedSnippet = key;
-		setTimeout(() => {
-			if (copiedSnippet === key) copiedSnippet = null;
-		}, 1600);
-	}
-
-	const installCommand = 'bunx @aidan-neel/ui add tooltip';
 </script>
 
 <svelte:head>
@@ -79,60 +61,13 @@
 	<meta name="description" content="Brief explanatory text on hover or focus." />
 </svelte:head>
 
-<header class="flex flex-col gap-5 border-b border-border/60 pb-10">
-	<div class="flex flex-wrap items-start justify-between gap-3">
-		<div class="flex flex-wrap items-center gap-2">
-			<Badge variant="outlined" icon={Component} iconSize={11} class="gap-1.5 text-[0.66rem]"
-				>Component</Badge
-			>
-			<Badge variant="outlined" class="text-[0.66rem]">v0.4.2</Badge>
-			<Badge variant="ghost" class="text-[0.66rem]">Floating UI</Badge>
-		</div>
-		<a
-			href={SOURCE}
-			target="_blank"
-			rel="noreferrer noopener"
-			class="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[0.7rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] text-foreground-muted transition-colors hover:bg-secondary/60 hover:text-foreground"
-		>
-			View source
-			<External size={11} />
-		</a>
-	</div>
-
-	<div class="flex flex-col gap-3">
-		<h1
-			class="m-0 text-[2.6rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] leading-[1] tracking-[-0.035em] md:text-[3rem]"
-			style="font-family: var(--font-header);"
-		>
-			Tooltip
-		</h1>
-		<p class="m-0 max-w-[42rem] text-[1rem] leading-relaxed text-foreground-muted">
-			A one-line hover hint for icons, abbreviations, and dense affordances. Mobile users won't see
-			it — never put critical info behind a tooltip.
-		</p>
-	</div>
-
-	<div
-		class="flex max-w-[28rem] items-stretch overflow-hidden rounded-[var(--radius-md)] border border-border bg-card"
-	>
-		<div class="flex flex-1 items-center gap-3 px-3 py-2.5">
-			<span class="grid size-6 place-items-center rounded-md bg-secondary/70 text-foreground-muted"
-				><Hash size={12} /></span
-			><code class="flex-1 font-mono text-[0.82rem] text-foreground">{installCommand}</code>
-		</div>
-		<button
-			type="button"
-			onclick={() => copy(installCommand, 'install')}
-			class="border-l border-border bg-card px-3 text-[0.78rem] text-foreground-muted transition-colors hover:bg-secondary/50 hover:text-foreground"
-			aria-label="Copy install command"
-		>
-			{#if copiedSnippet === 'install'}<Check
-					size={14}
-					class="text-[var(--color-success)]"
-				/>{:else}<Copy size={14} />{/if}
-		</button>
-	</div>
-</header>
+<DocHeader
+	title={TITLE}
+	description="A one-line hover hint for icons, abbreviations, and dense affordances. Mobile users won't see it — never put critical info behind a tooltip."
+	source={SOURCE}
+	install={installCommand}
+	pills={[{ label: 'v0.4.2', variant: 'outlined' }, { label: 'Floating UI' }]}
+/>
 
 <section class="pt-10">
 	<div class="relative">
@@ -188,85 +123,11 @@
 </section>
 
 <div class="flex flex-col gap-16 pt-16">
-	<section class="scroll-mt-20 flex flex-col gap-5">
-		<div class="flex items-center gap-2">
-			<span class="grid size-6 place-items-center rounded-md bg-primary/10 text-primary"
-				><Hash size={12} /></span
-			>
-			<h2
-				class="m-0 text-[1.4rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				API
-			</h2>
-		</div>
+	<DocSection icon={Hash} title="API">
+		<PropTable rows={apiRows} namespace="Tooltip" />
+	</DocSection>
 
-		<div class="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
-			<ul class="flex flex-col divide-y divide-border/60">
-				{#each apiRows as row}
-					<li class="grid grid-cols-[1fr_1.4fr_0.6fr] gap-3 px-4 py-3 max-md:grid-cols-1">
-						<div class="flex flex-col gap-1">
-							<code class="font-mono text-[0.7rem] text-foreground-muted"
-								>Tooltip.{row.component}</code
-							><code
-								class="font-mono text-[0.82rem] [font-weight:var(--font-weight-label,600)] [letter-spacing:var(--tracking-label,0em)]"
-								>{row.prop}</code
-							>
-						</div>
-						<div class="flex flex-col gap-1">
-							<code
-								class="overflow-x-auto rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.74rem] text-foreground"
-								>{row.type}</code
-							>
-							<p class="m-0 text-[0.78rem] leading-snug text-foreground-muted">{row.description}</p>
-						</div>
-						<div class="md:text-right">
-							<code
-								class="inline-block rounded-md bg-secondary/40 px-2 py-1 font-mono text-[0.72rem]"
-								>{row.default}</code
-							>
-						</div>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	</section>
-
-	<section
-		class="flex flex-col items-start justify-between gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-6 sm:flex-row sm:items-center"
-	>
-		<div class="flex flex-col gap-1">
-			<p
-				class="m-0 text-[1rem] [font-weight:var(--font-weight-label,500)] [letter-spacing:var(--tracking-label,0em)] tracking-tight"
-				style="font-family: var(--font-header);"
-			>
-				Want to make it yours?
-			</p>
-			<p class="m-0 text-[0.86rem] text-foreground-muted">
-				Every Silk component reads from your theme tokens — open the studio to restyle them.
-			</p>
-		</div>
-		<Button href="/themes/studio">Open theme studio<ArrowRight size={14} /></Button>
-	</section>
+	<DocFooter />
 </div>
 
-{#if curIndex !== -1}
-	<div
-		class="mt-12 flex w-full items-center"
-		class:justify-between={prevComponent && nextComponent}
-		class:justify-end={!prevComponent && nextComponent}
-		class:justify-start={prevComponent && !nextComponent}
-	>
-		{#if prevComponent}<Button
-				href={`/docs/components/${prevComponent}`}
-				variant="outlined"
-				class="flex-shrink-0"><ChevronLeft size={16} />{sanitizeComponent(prevComponent)}</Button
-			>{/if}
-		{#if prevComponent && nextComponent}<div class="mx-4 w-full rounded-lg border-t"></div>{/if}
-		{#if nextComponent}<Button
-				href={`/docs/components/${nextComponent}`}
-				variant="outlined"
-				class="flex-shrink-0">{sanitizeComponent(nextComponent)}<ChevronRight size={16} /></Button
-			>{/if}
-	</div>
-{/if}
+<DocPager slug={SLUG} />


### PR DESCRIPTION
## What

The 39 component doc pages were copy-pasted variants of one template that had drifted apart. This extracts Button's scaffolding into a small shared **doc-kit** and migrates every page onto it, so the framing is identical everywhere while each page keeps its own playground and demos.

## The drift this fixes

- **API tables**: three different grid ratios (`1fr_1.4fr_0.6fr`, `1fr_1.6fr_0.5fr`, `1fr_1.8fr_0.5fr`) — and only Button had the header row + click-to-copy prop names. Now every page uses one table.
- **Section headers**: iconned on some sections, plain on others. Now uniform.
- **Footer + prev/next pager**: duplicated verbatim in all 39 files.
- **Hero**: same block re-implemented 39 times with small variations.

## The kit (`apps/docs/src/lib/components/docs/`)

- `DocHeader` — hero: Component badge + pills, View source, title, lead paragraph, copyable install box
- `DocSection` — iconned `<h2>` header + optional description (the `<h2>` stays plain so the on-this-page TOC keeps working)
- `PropTable` — canonical API table (header row, click-to-copy props, single grid ratio); optional `namespace` for compound components (e.g. `Accordion.Root`)
- `DocFooter` — studio call-to-action
- `DocPager` — prev/next from the shared components list
- `copy.svelte.ts` — shared clipboard helper

Every page now reads: `DocHeader` → playground (bespoke) → `DocSection`s (bespoke demos inside) → API `DocSection` + `PropTable` → `DocFooter` → `DocPager`.

## Notes

- Each page's bespoke playground/demos and data arrays are preserved verbatim — only the repeated scaffolding changed. **Net ~5,000 fewer lines** (1,186 insertions / 6,267 deletions).
- One intentional content change: the per-component **footer** is now the shared studio CTA that 38 pages already used, so Button's bespoke footer (its one outlier block) is replaced for consistency.
- Two tiny copy deltas noted by the migration: `calendar`'s hero had `Intl` wrapped in `<code>` (DocHeader's description is plain text, so it renders as text); `label`/`marquee` API tables previously printed a per-row component name that the standard single-component table omits.

## Out of scope (flagging, not changing here)

Every page's install command still reads `bunx @aidan-neel/ui add <name>`, which is stale now that the CLI ships as `@silk-ui/cli` (`silk add <name>`). It's uniform across all pages, so it's a consistent-but-outdated string — worth a follow-up, separate from this layout pass.

## Verification

- `svelte-check`: 0 errors (the 5 warnings are pre-existing, in `packages/silk`)
- `eslint .`: 0 errors (98 warnings are pre-existing `require-each-key` in demo `{#each}` blocks)
- `prettier --check .`: clean
- `bun run build` (docs): succeeds
- `bun --filter=docs run test:ci`: 659/659 pass

https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjayEDRD6petvtMaGDkBmS)_