### PR TITLE
fix(docs): render code in component preview; add panel button variant

### DIFF
--- a/apps/docs/src/lib/components/docs/component-preview.svelte
+++ b/apps/docs/src/lib/components/docs/component-preview.svelte
@@ -56,7 +56,6 @@
 		<!-- Code is a CodeBlock — it carries its own Panel frame, so it stands alone. -->
 		<CodeBlock.Root
 			{...rest}
-			value="code"
 			{code}
 			lang="svelte"
 			copy="overlay"

--- a/apps/docs/src/routes/docs/components/button/+page.svelte
+++ b/apps/docs/src/routes/docs/components/button/+page.svelte
@@ -25,6 +25,8 @@
 	import VariantGhostSrc from './examples/variant-ghost.svelte?raw';
 	import VariantDestructive from './examples/variant-destructive.svelte';
 	import VariantDestructiveSrc from './examples/variant-destructive.svelte?raw';
+	import VariantPanel from './examples/variant-panel.svelte';
+	import VariantPanelSrc from './examples/variant-panel.svelte?raw';
 	import Sizes from './examples/sizes.svelte';
 	import SizesSrc from './examples/sizes.svelte?raw';
 	import Disabled from './examples/disabled.svelte';
@@ -232,6 +234,17 @@
 			</h3>
 			<ComponentPreview code={VariantDestructiveSrc}>
 				<VariantDestructive />
+			</ComponentPreview>
+		</div>
+
+		<div id="variant-panel" class="scroll-mt-20 flex flex-col gap-3">
+			<h3
+				class="text-[1rem] font-[var(--font-weight-header,600)] tracking-tight text-foreground docs-subsection-heading"
+			>
+				Panel
+			</h3>
+			<ComponentPreview code={VariantPanelSrc}>
+				<VariantPanel />
 			</ComponentPreview>
 		</div>
 

--- a/apps/docs/src/routes/docs/components/button/examples/variant-panel.svelte
+++ b/apps/docs/src/routes/docs/components/button/examples/variant-panel.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { Button } from '@silk/ui/components/button';
+</script>
+
+<Button variant="panel">Panel</Button>

--- a/apps/docs/tests/unit/silk/button.test.ts
+++ b/apps/docs/tests/unit/silk/button.test.ts
@@ -36,7 +36,7 @@ describe('Button -- rendering and DOM element selection', () => {
 });
 
 describe('Button -- variant prop wiring', () => {
-	const variants = ['primary', 'secondary', 'ghost', 'outline', 'destructive'] as const;
+	const variants = ['primary', 'secondary', 'ghost', 'outline', 'destructive', 'panel'] as const;
 
 	for (const variant of variants) {
 		it(`renders the "${variant}" variant without throwing`, () => {

--- a/packages/silk/src/components/button/button.svelte
+++ b/packages/silk/src/components/button/button.svelte
@@ -4,6 +4,8 @@
 	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 	import { cn } from '@silk/ui/utils';
 	import type { ButtonProps } from '.';
+	// `panel` variant reads Panel's `--panel-*` tokens (defined on `.panel-root`).
+	import '../panel/panel.css';
 	import { useState } from '@silk/ui/internals/state.svelte.ts';
 
 	let {

--- a/packages/silk/src/components/button/index.ts
+++ b/packages/silk/src/components/button/index.ts
@@ -3,7 +3,7 @@ import Button from './button.svelte';
 import type { Snippet } from 'svelte';
 import type { Intent } from '../../internals/variants';
 
-export type ButtonVariant = Intent;
+export type ButtonVariant = Intent | 'panel';
 
 export type ButtonProps = {
 	href?: string;

--- a/packages/silk/src/components/button/manifest.ts
+++ b/packages/silk/src/components/button/manifest.ts
@@ -24,20 +24,24 @@ import type { Manifest } from '@silk/ui/_manifest/types';
  *             are gone.
  *           - Coordinated with the F-29 collapse of tooltip and
  *             hover-card into popover wrappers.
+ *   3.2.0:
+ *           - Add the `panel` variant: a clickable Button wearing Panel's
+ *             concentric frame. Pulls Panel's `--panel-*` tokens, so button
+ *             now depends on `panel`.
  */
 export const manifest: Manifest = {
 	name: 'button',
-	version: '3.1.0',
+	version: '3.2.0',
 	visibility: 'public',
 	description:
-		'Click target with 5 intent variants and 4 sizes. Renders as <button> by default; renders as <a> when `href` is provided. Universal trigger primitive -- pulled by every interactive silk component.',
+		'Click target with 6 intent variants and 4 sizes. Renders as <button> by default; renders as <a> when `href` is provided. Universal trigger primitive -- pulled by every interactive silk component.',
 	files: [
 		'components/button/button.svelte',
 		'components/button/index.ts',
 		'components/button/variants.ts',
 		'components/button/manifest.ts'
 	],
-	components: [],
+	components: ['panel'],
 	shared: ['utils.cn', 'internals/state'],
 	peerDependencies: {
 		clsx: '^2.0.0',

--- a/packages/silk/src/components/button/variants.ts
+++ b/packages/silk/src/components/button/variants.ts
@@ -17,7 +17,13 @@ export const button = tv({
 			outline:
 				'bg-[var(--button-outlined-bg)] text-[var(--button-outlined-foreground)] shadow-[var(--button-outline-shadow)] hover:bg-[var(--button-outlined-hover-bg)] data-[state=open]:bg-[var(--button-outlined-hover-bg)] focus-visible:shadow-[var(--focus-ring),var(--button-outline-shadow)]',
 			destructive:
-				'bg-[var(--button-destructive-bg)] text-[var(--button-destructive-foreground)] hover:bg-[var(--button-destructive-hover-bg)] data-[state=open]:bg-[var(--button-destructive-hover-bg)]'
+				'bg-[var(--button-destructive-bg)] text-[var(--button-destructive-foreground)] hover:bg-[var(--button-destructive-hover-bg)] data-[state=open]:bg-[var(--button-destructive-hover-bg)]',
+			// A clickable Panel: same interaction as `outline`, but wearing Panel's
+			// concentric frame -- the hairline `--panel-border` outside and the inset
+			// surface ring inside read as Panel's double edge. Tokens come from the
+			// `panel-root` class (../panel/panel.css), imported by button.svelte.
+			panel:
+				'panel-root border border-[var(--panel-border)] bg-[var(--panel-bg)] text-[var(--panel-fg)] shadow-[var(--card-shadow)] ring-1 ring-inset ring-[color-mix(in_oklab,var(--panel-border)_50%,transparent)] hover:bg-[var(--button-outlined-hover-bg)] data-[state=open]:bg-[var(--button-outlined-hover-bg)] focus-visible:shadow-[var(--focus-ring),var(--card-shadow)]' // token-lint-disable-line no-literal-length
 		},
 		size: {
 			sm: '[--button-height:var(--size-control-sm)] px-[calc(var(--button-padding-x)_-_0.125rem)]', // token-lint-disable-line no-literal-length


### PR DESCRIPTION
## Summary

Two fixes for the docs/component layer:

### 1. Code not rendering in the component preview's "Code" tab
`component-preview.svelte` passed `value="code"` to `CodeBlock.Root`. For a single `code` snippet, CodeBlock registers its content panel under an internal sentinel value (`__single__`), and a panel only renders when `activeValue === value`. The `value="code"` override set the active tab to `"code"`, which never matched `__single__`, so the content panel stayed `display: none` — no code showed. Removed the override so it falls back to the correct internal default.

### 2. New `panel` Button variant
A clickable Panel styled as a button — same interaction as `outline`, but wearing Panel's concentric frame (hairline `--panel-border` outside + inset surface ring inside), pulling Panel's `--panel-*` tokens.

- `button/variants.ts` — added the `panel` variant
- `button/index.ts` — `ButtonVariant = Intent | 'panel'` (kept separate from the shared `INTENTS` so it doesn't leak into other Intent consumers like badge/alert)
- `button/button.svelte` — imports `panel.css` so the `--panel-*` tokens resolve
- `button/manifest.ts` — declared the new `panel` dependency, bumped to `3.2.0`
- Docs: added `variant-panel.svelte` example + a "Panel" showcase section; added `panel` to the button variant test loop

## Verification
- All 471 docs unit/SSR tests pass
- `svelte-check` reports 0 errors (only pre-existing warnings)

## Note
`code-block` imports `panel.css` the same way but doesn't declare `panel` in its manifest — looks like a pre-existing metadata gap, left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUTiiexuEQX9Q7sG2fBAWj)_