### PR TITLE
feat(docs): sidebar panel treatment

### DIFF
--- a/apps/docs/src/lib/components/docs/side-navbar.svelte
+++ b/apps/docs/src/lib/components/docs/side-navbar.svelte
@@ -51,6 +51,8 @@
 		</div>
 	</section>
 
+	<div class="mx-2 border-t border-border/50"></div>
+
 	<section class="flex flex-col gap-1.5">
 		<div class="flex items-center justify-between px-2">
 			<h3

--- a/apps/docs/src/routes/docs/+layout.svelte
+++ b/apps/docs/src/routes/docs/+layout.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <SideNavbar
-	class="hidden sticky top-16 h-[calc(100vh-4rem)] w-64 flex-shrink-0 border-r border-border pt-8 lg:flex"
+	class="hidden sticky top-16 h-[calc(100vh-4rem)] w-64 flex-shrink-0 border-r border-border bg-[color-mix(in_srgb,var(--color-foreground)_4%,transparent)] pl-4 pt-8 lg:flex"
 />
 <div class="flex w-full min-w-0 flex-1 justify-center lg:px-10">
 	<div


### PR DESCRIPTION
## Summary

Follow-up to #91 (bordered app-shell). Adds the **sidebar panel treatment** so the left nav reads as a distinct surface rather than transparent columns.

### Changes
- **`docs/+layout.svelte`**: the sidebar rail gets a subtle, theme-adaptive panel background (`color-mix` of `--color-foreground` at 4%, so it adapts to light/dark) plus inner left padding. Scoped to the desktop rail only — the mobile nav sheet is unaffected.
- **`side-navbar.svelte`**: a faint divider between the *Getting Started* and *Components* groups for tighter grouping.

Layout/visual polish only.

## Stacking
This PR is **stacked on `claude/docs-bordered-shell` (#91)** and targets that branch, so the diff shows only the sidebar-panel changes. Merge #91 first; once it lands, this can be retargeted to `studio-original-styling` (or merged via the stack).

## Verification
- `svelte-check`: 0 errors.
- Not visually verified — the sandbox blocks the Playwright Chromium download. Worth a quick local look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUTiiexuEQX9Q7sG2fBAWj)_