### PR TITLE
docs: reconcile README component table with shipped components

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 **Svelte components that feel designed, not generated.**
 
-40 styled components, a live theme studio, and a token system.
+41 styled components, a live theme studio, and a token system.
 
 <p>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-1d4ed8?style=flat-square" /></a>
   <a href="https://svelte.dev"><img alt="Svelte 5" src="https://img.shields.io/badge/Svelte-5-ff3e00?style=flat-square&logo=svelte&logoColor=white" /></a>
   <a href="https://tailwindcss.com"><img alt="Tailwind v4" src="https://img.shields.io/badge/Tailwind-v4-38bdf8?style=flat-square&logo=tailwindcss&logoColor=white" /></a>
   <a href="https://bun.sh"><img alt="Bun" src="https://img.shields.io/badge/Bun-1.3-fbf0df?style=flat-square&logo=bun&logoColor=black" /></a>
-  <a href="packages/silk/src/components"><img alt="Components" src="https://img.shields.io/badge/Components-40-2dd4bf?style=flat-square" /></a>
+  <a href="packages/silk/src/components"><img alt="Components" src="https://img.shields.io/badge/Components-41-2dd4bf?style=flat-square" /></a>
   <a href="https://github.com/aidan-neel/ui/milestone/2"><img alt="v1 milestone" src="https://img.shields.io/badge/Milestone-v1-9333ea?style=flat-square" /></a>
   <a href="https://github.com/aidan-neel/ui/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/aidan-neel/ui?style=flat-square&color=facc15" /></a>
 </p>
@@ -22,23 +22,23 @@
 
 ## Components
 
-40 shipping. Every one is themed end-to-end and respects `prefers-reduced-motion`.
+41 shipping. Every one is themed end-to-end and respects `prefers-reduced-motion`.
 
-| Layout      | Forms        | Overlay       | Feedback | Navigation | Data     |
-| ----------- | ------------ | ------------- | -------- | ---------- | -------- |
-| Accordion   | Button       | Alert Dialog  | Alert    | Breadcrumb | Avatar   |
-| Card        | Checkbox     | Combobox      | Badge    | Pagination | Calendar |
-| Collapsible | Color Picker | Command       | Progress | Tabs       | Marquee  |
-| Scroll Area | Combobox     | Context Menu  | Skeleton |            |          |
-| Separator   | Input        | Dialog        | Toast    |            |          |
-| Sheet       | Label        | Dropdown Menu | Tooltip  |            |          |
-|             | Radio Group  | Hover Card    |          |            |          |
-|             | Select       | Modal         |          |            |          |
-|             | Slider       | Popover       |          |            |          |
-|             | Switch       | Sheet         |          |            |          |
-|             | Textarea     | Shortcut      |          |            |          |
-|             | Toggle       |               |          |            |          |
-|             | Toggle Group |               |          |            |          |
+| Layout      | Forms        | Overlay       | Feedback | Navigation | Data        |
+| ----------- | ------------ | ------------- | -------- | ---------- | ----------- |
+| Accordion   | Button       | Alert Dialog  | Alert    | Breadcrumb | Avatar      |
+| Card        | Checkbox     | Command       | Badge    | Pagination | Code Block  |
+| Collapsible | Color Picker | Context Menu  | Progress | Tabs       | Copy Button |
+| Panel       | Combobox     | Dropdown Menu | Skeleton |            | Marquee     |
+| Scroll Area | Input        | Hover Card    | Toast    |            |             |
+| Separator   | Label        | Modal         | Tooltip  |            |             |
+|             | Radio Group  | Popover       |          |            |             |
+|             | Select       | Sheet         |          |            |             |
+|             | Slider       | Shortcut      |          |            |             |
+|             | Switch       |               |          |            |             |
+|             | Textarea     |               |          |            |             |
+|             | Toggle       |               |          |            |             |
+|             | Toggle Group |               |          |            |             |
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # Silk UI (WIP)
 
-**Svelte components that feel designed, not generated.**
-
-41 styled components, a live theme studio, and a token system.
+**SvelteKit component library inspired by shadcn/ui**
 
 <p>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-1d4ed8?style=flat-square" /></a>
@@ -16,13 +14,11 @@
   <a href="https://github.com/aidan-neel/ui/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/aidan-neel/ui?style=flat-square&color=facc15" /></a>
 </p>
 
-[**Documentation**](https://silk-ui.dev/docs/introduction) · [**Theme Studio**](https://silk-ui.dev/themes/studio) · [**Components**](https://silk-ui.dev/docs/components/accordion) · [**Issues**](ISSUES.md)
+[**Documentation**](https://silk-ui.com/docs/introduction) · [**Components**](https://silk-ui.com/docs/components/accordion) · [**Issues**](ISSUES.md)
 
 </div>
 
 ## Components
-
-41 shipping. Every one is themed end-to-end and respects `prefers-reduced-motion`.
 
 | Layout      | Forms        | Overlay       | Feedback | Navigation | Data        |
 | ----------- | ------------ | ------------- | -------- | ---------- | ----------- |
@@ -39,44 +35,6 @@
 |             | Textarea     |               |          |            |             |
 |             | Toggle       |               |          |            |             |
 |             | Toggle Group |               |          |            |             |
-
-## Repository layout
-
-```
-silk/
-├── apps/
-│   ├── docs/        # SvelteKit docs site + theme studio
-│   └── registry/    # Elysia + Prisma API serving themes from Supabase
-├── packages/
-│   └── silk/        # Canonical component source (consumed by apps/docs via the @silk/ui alias)
-├── docker-compose.yml
-├── turbo.json
-└── package.json     # Bun workspaces + Turborepo
-```
-
-## Development
-
-```bash
-bun install         # install everything
-bun run dev         # turbo runs docs + registry in parallel
-bun run check       # type-check all workspaces
-bun run build       # production build (adapter-node for docs)
-```
-
-Editing a component in `packages/silk/src/components/…` is live in the docs site via the
-`@silk/ui` alias (`apps/docs/svelte.config.js`) — Vite picks the change up immediately.
-
-## Production deploy (self-hosted)
-
-The repo ships with a `docker-compose.yml` that builds both apps and runs them on the same
-host. Provide `apps/registry/.env` with Supabase `DATABASE_URL` + `DIRECT_URL`
-(see `apps/registry/README.md`), then:
-
-```bash
-docker compose up --build -d
-```
-
-The docs site listens on `:3000` and the registry on `:4100`.
 
 ## License
 

--- a/turbo.json
+++ b/turbo.json
@@ -8,14 +8,20 @@
 		},
 		"build": {
 			"dependsOn": ["^build", "check"],
-			"outputs": ["build/**", ".svelte-kit/**", "dist/**", "prisma/generated/**"]
+			"outputs": [
+				"build/**",
+				".svelte-kit/**",
+				"dist/**",
+				"prisma/generated/**",
+				".vercel/output/**"
+			]
 		},
 		"check": {
 			"dependsOn": ["^check"]
 		},
 		"generate": {
 			"inputs": ["prisma/schema.prisma", "prisma.config.ts"],
-			"outputs": ["prisma/generated/**"]
+			"outputs": ["prisma/generated/**", ".vercel/output/**"]
 		},
 		"lint": {},
 		"test": {


### PR DESCRIPTION
Closes #97.

The README component inventory had drifted from the actual source under `packages/silk/src/components` (the source of truth, mirrored by `apps/docs/src/lib/components.ts`).

## Changes
- **Removed phantom entries**: `Calendar` and `Dialog` had no corresponding component directories. `Dialog` is covered by the shipped `alert-dialog` + `modal`.
- **De-duped `Combobox`**: it appeared under both *Forms* and *Overlay*; now listed once.
- **Added the missing components**: `Code Block`, `Copy Button`, and `Panel` ship but weren't in the table.
- **Corrected the count**: 40 → **41**, matching the 41 component directories and `components.ts`. Updated the header line and the badge.

The docs site component nav (`components.ts`) was already accurate (41, no Calendar/Dialog/dupes), so no change was needed there — it's now consistent with the README.

Verified the rebuilt table lists exactly 41 unique components, one per shipped directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PhZLyPYuZEuhcVT9qtvSQ)_