### PR TITLE
feat: custom floating-ui implementation

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -56,7 +56,6 @@
 		"vitest-browser-svelte": "^2.1.1"
 	},
 	"dependencies": {
-		"@floating-ui/dom": "^1.7.6",
 		"@lucide/svelte": "^1.7.0",
 		"@silk/ui": "workspace:*",
 		"clsx": "^2.1.1",

--- a/apps/docs/tests/unit/silk/floating.test.ts
+++ b/apps/docs/tests/unit/silk/floating.test.ts
@@ -133,6 +133,20 @@ describe('computePosition — middleware', () => {
 		expect(placement).toBe('bottom');
 	});
 
+	it('flip() does NOT flip when only the cross axis overflows (shift handles it)', async () => {
+		// A bottom-start panel anchored near the right edge hangs off the right
+		// (cross axis), but there is room below -- it must stay on bottom, not
+		// jump to a perpendicular/opposite side. Regression test for the dropdown
+		// that collapsed to a thin strip at the wrong spot.
+		const ref = virtualRef(980, 100, 20, 20); // viewport width is 1024
+		const floating = makeFloating(200, 100);
+		const { placement } = await computePosition(ref, floating, {
+			placement: 'bottom-start',
+			middleware: [flip({ padding: 8, crossAxis: true, fallbackAxisSideDirection: 'start' })]
+		});
+		expect(placement).toBe('bottom-start');
+	});
+
 	it('shift() slides the panel back inside the viewport', async () => {
 		// bottom-start would push a wide panel past the right edge; shift pulls it in.
 		const ref = virtualRef(1000, 100, 20, 20);

--- a/apps/docs/tests/unit/silk/floating.test.ts
+++ b/apps/docs/tests/unit/silk/floating.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+	computePosition,
+	offset,
+	flip,
+	shift,
+	size,
+	type Placement,
+	type VirtualElement
+} from '@silk/ui/internals/floating';
+
+// jsdom does no layout, so we stub the two geometry inputs the engine reads:
+// the reference's bounding rect (via a virtual element) and the floating
+// element's bounding rect + offsetParent. window.innerWidth/Height default to
+// 1024x768 in jsdom, which we treat as the viewport.
+
+function virtualRef(x: number, y: number, width: number, height: number): VirtualElement {
+	return {
+		getBoundingClientRect: () =>
+			({
+				x,
+				y,
+				top: y,
+				left: x,
+				right: x + width,
+				bottom: y + height,
+				width,
+				height,
+				toJSON: () => ({})
+			}) as DOMRect
+	};
+}
+
+function makeFloating(width: number, height: number): HTMLElement {
+	const el = document.createElement('div');
+	document.body.appendChild(el);
+	el.getBoundingClientRect = () =>
+		({
+			x: 0,
+			y: 0,
+			top: 0,
+			left: 0,
+			right: width,
+			bottom: height,
+			width,
+			height,
+			toJSON: () => ({})
+		}) as DOMRect;
+	// In the app the floating element is position:absolute in <body>; body sits
+	// at the viewport origin in jsdom, so the absolute-strategy conversion is a
+	// no-op here (which keeps these assertions in viewport coordinates).
+	Object.defineProperty(el, 'offsetParent', { get: () => document.body, configurable: true });
+	return el;
+}
+
+beforeEach(() => {
+	(window as unknown as { innerWidth: number }).innerWidth = 1024;
+	(window as unknown as { innerHeight: number }).innerHeight = 768;
+});
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('computePosition — base placements', () => {
+	it('centers along the cross axis for a bare side placement', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const { x, y, placement } = await computePosition(ref, floating, { placement: 'bottom' });
+		// bottom: y = ref.bottom (120); x centered = 100 + 25 - 50 = 75
+		expect(x).toBe(75);
+		expect(y).toBe(120);
+		expect(placement).toBe('bottom');
+	});
+
+	it('aligns to the start edge for "-start"', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const { x, y } = await computePosition(ref, floating, { placement: 'bottom-start' });
+		expect(x).toBe(100); // start aligns floating's left with the reference's left
+		expect(y).toBe(120);
+	});
+
+	it('aligns to the end edge for "-end"', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const { x } = await computePosition(ref, floating, { placement: 'bottom-end' });
+		// end: ref.right - floating.width = 150 - 100 = 50
+		expect(x).toBe(50);
+	});
+
+	it('places to the left/right along the x axis', async () => {
+		const ref = virtualRef(200, 200, 40, 40);
+		const floating = makeFloating(60, 30);
+		const right = await computePosition(ref, floating, { placement: 'right' });
+		expect(right.x).toBe(240); // ref.right
+		const left = await computePosition(ref, floating, { placement: 'left' });
+		expect(left.x).toBe(140); // ref.left - floating.width = 200 - 60
+	});
+});
+
+describe('computePosition — middleware', () => {
+	it('offset() pushes the floating element away from the reference', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const { y } = await computePosition(ref, floating, {
+			placement: 'bottom',
+			middleware: [offset(8)]
+		});
+		expect(y).toBe(128); // 120 + 8
+	});
+
+	it('flip() swaps to the opposite side when the preferred side overflows', async () => {
+		// Reference near the bottom edge: a 600px-tall panel can't fit below.
+		const ref = virtualRef(100, 740, 50, 20);
+		const floating = makeFloating(100, 600);
+		const { y, placement } = await computePosition(ref, floating, {
+			placement: 'bottom',
+			middleware: [flip({ padding: 8 })]
+		});
+		expect(placement).toBe('top');
+		// top: ref.top - floating.height = 740 - 600 = 140
+		expect(y).toBe(140);
+	});
+
+	it('flip() keeps the preferred side when it fits', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const { placement } = await computePosition(ref, floating, {
+			placement: 'bottom',
+			middleware: [flip({ padding: 8 })]
+		});
+		expect(placement).toBe('bottom');
+	});
+
+	it('shift() slides the panel back inside the viewport', async () => {
+		// bottom-start would push a wide panel past the right edge; shift pulls it in.
+		const ref = virtualRef(1000, 100, 20, 20);
+		const floating = makeFloating(200, 40);
+		const { x } = await computePosition(ref, floating, {
+			placement: 'bottom-start',
+			middleware: [shift({ padding: 8 })]
+		});
+		// right clip = 1024 - 8 = 1016; max left = 1016 - 200 = 816
+		expect(x).toBe(816);
+	});
+
+	it('size() reports the available space to apply()', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		let reported: { availableWidth: number; availableHeight: number } | undefined;
+		await computePosition(ref, floating, {
+			placement: 'bottom',
+			middleware: [
+				size({
+					padding: 8,
+					apply({ availableWidth, availableHeight }) {
+						reported = { availableWidth, availableHeight };
+					}
+				})
+			]
+		});
+		// Fully on-screen → available space equals the panel's own size.
+		expect(reported).toEqual({ availableWidth: 100, availableHeight: 40 });
+	});
+});
+
+describe('computePosition — strategy', () => {
+	it('returns the resolved placement and strategy', async () => {
+		const ref = virtualRef(100, 100, 50, 20);
+		const floating = makeFloating(100, 40);
+		const result = await computePosition(ref, floating, {
+			placement: 'top-end' as Placement,
+			strategy: 'fixed'
+		});
+		expect(result.strategy).toBe('fixed');
+		expect(result.placement).toBe('top-end');
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
       "name": "docs",
       "version": "0.0.1",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6",
         "@lucide/svelte": "^1.7.0",
         "@silk/ui": "workspace:*",
         "clsx": "^2.1.1",
@@ -85,7 +84,6 @@
       "name": "@silk/ui",
       "version": "0.0.0",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6",
         "@lucide/svelte": "^1.7.0",
         "clsx": "^2.1.1",
         "fuse.js": "^7.1.0",
@@ -227,12 +225,6 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
-
-    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
-
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
-
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 

--- a/packages/silk/package.json
+++ b/packages/silk/package.json
@@ -7,7 +7,6 @@
 		"**/*.css"
 	],
 	"dependencies": {
-		"@floating-ui/dom": "^1.7.6",
 		"@lucide/svelte": "^1.7.0",
 		"clsx": "^2.1.1",
 		"fuse.js": "^7.1.0",

--- a/packages/silk/src/components/combobox/combobox-content.svelte
+++ b/packages/silk/src/components/combobox/combobox-content.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { HTMLButtonAttributes } from 'svelte/elements';
 	import { Button, type ButtonProps } from '@silk/ui/components/button';
-	import { computePosition, flip } from '@floating-ui/dom';
 	import { getContext, onMount, type Snippet } from 'svelte';
 	import { states } from '@silk/ui/internals/state.svelte.ts';
 	import type { ComboboxState } from '.';

--- a/packages/silk/src/components/combobox/combobox-results.svelte
+++ b/packages/silk/src/components/combobox/combobox-results.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { HTMLButtonAttributes } from 'svelte/elements';
 	import { Button, type ButtonProps } from '@silk/ui/components/button';
-	import { computePosition, flip } from '@floating-ui/dom';
 	import { getContext, onMount, type Snippet } from 'svelte';
 	import { states } from '@silk/ui/internals/state.svelte.ts';
 	import type { ComboboxState } from '.';

--- a/packages/silk/src/components/context-menu/context-menu-trigger.svelte
+++ b/packages/silk/src/components/context-menu/context-menu-trigger.svelte
@@ -2,7 +2,7 @@
 	import { states, type UIState } from '@silk/ui/internals/state.svelte.ts';
 	import { getContext } from 'svelte';
 	import { type ContextMenuState, type ContextMenuTriggerProps } from '.';
-	import type { VirtualElement } from '@floating-ui/dom';
+	import type { VirtualElement } from '@silk/ui/internals/floating';
 
 	const key = getContext<string>('key');
 	const uiState = states[key].data as ContextMenuState;

--- a/packages/silk/src/components/context-menu/index.ts
+++ b/packages/silk/src/components/context-menu/index.ts
@@ -10,7 +10,7 @@ import Trigger from './context-menu-trigger.svelte';
 
 import type { DefaultProps } from '@silk/ui/utils';
 import type { PopoverState } from '../popover';
-import type { VirtualElement } from '@floating-ui/dom';
+import type { VirtualElement } from '@silk/ui/internals/floating';
 import type { ButtonProps } from '../button';
 
 export type ContextMenuProps = {} & DefaultProps;

--- a/packages/silk/src/components/context-menu/manifest.ts
+++ b/packages/silk/src/components/context-menu/manifest.ts
@@ -5,7 +5,7 @@ export const manifest: Manifest = {
 	version: '1.0.0',
 	visibility: 'public',
 	description:
-		'Right-click contextual menu with sub-menus and checkbox items. Positioned via @floating-ui virtual element.',
+		'Right-click contextual menu with sub-menus and checkbox items. Positioned via a virtual reference element.',
 	role: 'menu',
 	files: [
 		'components/context-menu/context-menu.svelte',
@@ -23,7 +23,6 @@ export const manifest: Manifest = {
 	components: ['popover', 'button'],
 	shared: ['utils.cn', 'internals/state'],
 	peerDependencies: {
-		'@floating-ui/dom': '^1.0.0',
 		clsx: '^2.0.0',
 		'tailwind-merge': '^3.0.0',
 		svelte: '^5.0.0'

--- a/packages/silk/src/components/marquee/popover/index.ts
+++ b/packages/silk/src/components/marquee/popover/index.ts
@@ -7,7 +7,7 @@ import type { DefaultProps } from '@silk/ui/utils';
 import type { Snippet } from 'svelte';
 import type { UIState } from '@silk/ui/internals/state.svelte.ts';
 import type { ButtonVariant } from '@silk/ui/components/button';
-import type { VirtualElement } from '@floating-ui/dom';
+import type { VirtualElement } from '@silk/ui/internals/floating';
 import type { HTMLAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
 export type PopoverContentProps = {

--- a/packages/silk/src/components/marquee/popover/manifest.ts
+++ b/packages/silk/src/components/marquee/popover/manifest.ts
@@ -26,7 +26,7 @@ export const manifest: Manifest = {
 	version: '2.0.0',
 	visibility: 'public',
 	description:
-		'Floating content positioned by @floating-ui. Click or hover triggers, Title/Content subparts, click-outside + Escape dismiss, optional portal.',
+		'Floating content positioned by the built-in floating engine. Click or hover triggers, Title/Content subparts, click-outside + Escape dismiss, optional portal.',
 	role: 'dialog',
 	files: [
 		'components/popover/popover.svelte',
@@ -45,7 +45,6 @@ export const manifest: Manifest = {
 		'internals/transition'
 	],
 	peerDependencies: {
-		'@floating-ui/dom': '^1.0.0',
 		clsx: '^2.0.0',
 		'tailwind-merge': '^3.0.0',
 		svelte: '^5.0.0'

--- a/packages/silk/src/components/marquee/popover/popover-content.svelte
+++ b/packages/silk/src/components/marquee/popover/popover-content.svelte
@@ -61,7 +61,7 @@
 	import { clickOutside, cn, positionFloatingPanel, trapFocus } from '@silk/ui/utils';
 	import { createPresence } from '@silk/ui/internals/presence.svelte.ts';
 	import { getContext } from 'svelte';
-	import type { ReferenceElement } from '@floating-ui/dom';
+	import type { ReferenceElement } from '@silk/ui/internals/floating';
 	import { PANEL_FRAME, PANEL_SURFACE } from '../../panel';
 	import '../../panel/panel.css';
 	import type { PopoverContentProps, PopoverState } from '.';

--- a/packages/silk/src/components/popover/index.ts
+++ b/packages/silk/src/components/popover/index.ts
@@ -7,7 +7,7 @@ import type { DefaultProps } from '@silk/ui/utils';
 import type { Snippet } from 'svelte';
 import type { UIState } from '@silk/ui/internals/state.svelte.ts';
 import type { ButtonVariant } from '@silk/ui/components/button';
-import type { VirtualElement } from '@floating-ui/dom';
+import type { VirtualElement } from '@silk/ui/internals/floating';
 import type { HTMLAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
 export type PopoverContentProps = {

--- a/packages/silk/src/components/popover/manifest.ts
+++ b/packages/silk/src/components/popover/manifest.ts
@@ -26,7 +26,7 @@ export const manifest: Manifest = {
 	version: '2.0.0',
 	visibility: 'public',
 	description:
-		'Floating content positioned by @floating-ui. Click or hover triggers, Title/Content subparts, click-outside + Escape dismiss, optional portal.',
+		'Floating content positioned by the built-in floating engine. Click or hover triggers, Title/Content subparts, click-outside + Escape dismiss, optional portal.',
 	role: 'dialog',
 	files: [
 		'components/popover/popover.svelte',
@@ -45,7 +45,6 @@ export const manifest: Manifest = {
 		'internals/transition'
 	],
 	peerDependencies: {
-		'@floating-ui/dom': '^1.0.0',
 		clsx: '^2.0.0',
 		'tailwind-merge': '^3.0.0',
 		svelte: '^5.0.0'

--- a/packages/silk/src/components/tooltip/manifest.ts
+++ b/packages/silk/src/components/tooltip/manifest.ts
@@ -36,7 +36,6 @@ export const manifest: Manifest = {
 	components: [],
 	shared: ['utils.cn'],
 	peerDependencies: {
-		'@floating-ui/dom': '^1.0.0',
 		'slot-text': '^0.3.0',
 		clsx: '^2.0.0',
 		'tailwind-merge': '^3.0.0',

--- a/packages/silk/src/components/tooltip/shared-tooltip.ts
+++ b/packages/silk/src/components/tooltip/shared-tooltip.ts
@@ -6,7 +6,7 @@
 // Centering trick: the bubble is anchored by its *center* (left = trigger
 // centre + translateX(-50%)), so its width can change freely without ever
 // drifting off the trigger.
-import { computePosition, offset, flip, shift, type Placement } from '@floating-ui/dom';
+import { computePosition, offset, flip, shift, type Placement } from '@silk/ui/internals/floating';
 import { slotText, type SlotTextController } from 'slot-text';
 import 'slot-text/style.css';
 

--- a/packages/silk/src/internals/floating.ts
+++ b/packages/silk/src/internals/floating.ts
@@ -222,12 +222,7 @@ function getOppositeAxisPlacements(placement: Placement, direction: 'start' | 'e
 
 /** Swaps to the opposite (or a fallback) placement when the current one overflows. */
 export function flip(options: FlipOptions = {}): Middleware {
-	const {
-		padding = 0,
-		crossAxis: checkCrossAxis = true,
-		fallbackPlacements,
-		fallbackAxisSideDirection = 'none'
-	} = options;
+	const { padding = 0, fallbackPlacements, fallbackAxisSideDirection = 'none' } = options;
 
 	return {
 		name: 'flip',
@@ -247,22 +242,13 @@ export function flip(options: FlipOptions = {}): Middleware {
 
 			const overflow = detectOverflow(state, padding);
 			const side = getSide(placement);
+			const mainOverflow = overflow[side];
+			const overflows = [...(data.overflows ?? []), { placement, overflow: mainOverflow }];
 
-			// Track overflow on the main side (and, optionally, the alignment axis).
-			const checks: number[] = [overflow[side]];
-			if (checkCrossAxis) {
-				const alignment = getAlignment(placement);
-				if (alignment) {
-					const alignAxis: Axis = getSideAxis(placement) === 'y' ? 'x' : 'y';
-					const a: Side = alignAxis === 'x' ? 'left' : 'top';
-					const b: Side = alignAxis === 'x' ? 'right' : 'bottom';
-					checks.push(overflow[a], overflow[b]);
-				}
-			}
-
-			const overflows = [...(data.overflows ?? []), { placement, overflow: overflow[side] }];
-
-			if (!checks.every((o) => o <= 0)) {
+			// Only the main (side) axis decides a flip. Cross-axis (alignment)
+			// overflow is left to shift(), so a panel anchored near a viewport
+			// edge slides into view instead of flipping to a perpendicular side.
+			if (mainOverflow > 0) {
 				const nextIndex = (data.index ?? 0) + 1;
 				const nextPlacement = placements[nextIndex];
 				if (nextPlacement) {
@@ -271,7 +257,7 @@ export function flip(options: FlipOptions = {}): Middleware {
 						reset: { placement: nextPlacement }
 					};
 				}
-				// Nothing fit on its main side: fall back to whichever overflowed least.
+				// Exhausted: keep whichever placement overflowed its side the least.
 				const best = [...overflows].sort((p, q) => p.overflow - q.overflow)[0]?.placement;
 				if (best && best !== placement) {
 					return { data: { placements }, reset: { placement: best } };

--- a/packages/silk/src/internals/floating.ts
+++ b/packages/silk/src/internals/floating.ts
@@ -1,0 +1,436 @@
+/**
+ * Silk's built-in floating-element positioning engine.
+ *
+ * A small, dependency-free replacement for the subset of `@floating-ui/dom`
+ * that Silk uses: `computePosition` plus the `offset`, `flip`, `shift` and
+ * `size` middleware. The public shapes (placements, the middleware factory
+ * signatures, the `computePosition` return) mirror floating-ui so existing
+ * call sites keep working unchanged.
+ *
+ * Model: middleware run in **viewport** coordinates (so overflow detection is
+ * straightforward), then the final coordinates are converted into the floating
+ * element's containing block for the `absolute` strategy. For `fixed`, viewport
+ * coordinates are returned as-is.
+ */
+
+export type Side = 'top' | 'right' | 'bottom' | 'left';
+export type Alignment = 'start' | 'end';
+export type Placement = Side | `${Side}-${Alignment}`;
+export type Strategy = 'absolute' | 'fixed';
+export type Axis = 'x' | 'y';
+
+export interface Rect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface VirtualElement {
+	getBoundingClientRect: () => DOMRect | Rect;
+	contextElement?: Element;
+}
+
+export type ReferenceElement = Element | VirtualElement;
+export type FloatingElement = HTMLElement;
+
+export interface MiddlewareState {
+	x: number;
+	y: number;
+	initialPlacement: Placement;
+	placement: Placement;
+	strategy: Strategy;
+	rects: { reference: Rect; floating: Rect };
+	elements: { reference: ReferenceElement; floating: FloatingElement };
+	middlewareData: MiddlewareData;
+}
+
+export interface MiddlewareReturn {
+	x?: number;
+	y?: number;
+	data?: Record<string, unknown>;
+	reset?: boolean | { placement?: Placement };
+}
+
+export interface Middleware {
+	name: string;
+	fn: (state: MiddlewareState) => MiddlewareReturn | void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MiddlewareData = Record<string, any>;
+
+export interface ComputePositionConfig {
+	placement?: Placement;
+	strategy?: Strategy;
+	middleware?: Array<Middleware | null | undefined | false>;
+}
+
+export interface ComputePositionReturn {
+	x: number;
+	y: number;
+	placement: Placement;
+	strategy: Strategy;
+	middlewareData: MiddlewareData;
+}
+
+type SideObject = { top: number; right: number; bottom: number; left: number };
+
+const sides: Side[] = ['top', 'right', 'bottom', 'left'];
+
+function getSide(placement: Placement): Side {
+	return placement.split('-')[0] as Side;
+}
+
+function getAlignment(placement: Placement): Alignment | undefined {
+	return placement.split('-')[1] as Alignment | undefined;
+}
+
+/** The axis a side lives on: top/bottom → y, left/right → x. */
+function getSideAxis(placement: Placement): Axis {
+	return getSide(placement) === 'top' || getSide(placement) === 'bottom' ? 'y' : 'x';
+}
+
+const oppositeSide: Record<Side, Side> = {
+	top: 'bottom',
+	bottom: 'top',
+	left: 'right',
+	right: 'left'
+};
+
+function getOppositePlacement(placement: Placement): Placement {
+	const side = getSide(placement);
+	const alignment = getAlignment(placement);
+	return (alignment ? `${oppositeSide[side]}-${alignment}` : oppositeSide[side]) as Placement;
+}
+
+function clamp(min: number, value: number, max: number): number {
+	return Math.max(min, Math.min(value, max));
+}
+
+function getViewportRect(reference: ReferenceElement): Rect {
+	const r = reference.getBoundingClientRect();
+	return { x: r.x, y: r.y, width: r.width, height: r.height };
+}
+
+/** Base coordinates (viewport space) for a placement, before middleware. */
+function computeCoordsFromPlacement(
+	reference: Rect,
+	floating: Rect,
+	placement: Placement
+): { x: number; y: number } {
+	const commonX = reference.x + reference.width / 2 - floating.width / 2;
+	const commonY = reference.y + reference.height / 2 - floating.height / 2;
+	const side = getSide(placement);
+	const alignment = getAlignment(placement);
+
+	let coords: { x: number; y: number };
+	switch (side) {
+		case 'top':
+			coords = { x: commonX, y: reference.y - floating.height };
+			break;
+		case 'bottom':
+			coords = { x: commonX, y: reference.y + reference.height };
+			break;
+		case 'right':
+			coords = { x: reference.x + reference.width, y: commonY };
+			break;
+		case 'left':
+		default:
+			coords = { x: reference.x - floating.width, y: commonY };
+			break;
+	}
+
+	if (alignment) {
+		// Alignment shifts along the axis perpendicular to the side.
+		const alignmentAxis: Axis = getSideAxis(placement) === 'y' ? 'x' : 'y';
+		const len = alignmentAxis === 'y' ? 'height' : 'width';
+		const diff = reference[len] / 2 - floating[len] / 2;
+		if (alignment === 'start') coords[alignmentAxis] -= diff;
+		else coords[alignmentAxis] += diff;
+	}
+
+	return coords;
+}
+
+/**
+ * How far the floating rect (at the given viewport coords) spills past the
+ * viewport, inset by `padding`. Positive on a side = overflowing that side.
+ */
+function detectOverflow(state: MiddlewareState, padding: number): SideObject {
+	const { x, y, rects } = state;
+	const floating = {
+		top: y,
+		left: x,
+		right: x + rects.floating.width,
+		bottom: y + rects.floating.height
+	};
+	const clip = {
+		top: padding,
+		left: padding,
+		right: window.innerWidth - padding,
+		bottom: window.innerHeight - padding
+	};
+	return {
+		top: clip.top - floating.top,
+		bottom: floating.bottom - clip.bottom,
+		left: clip.left - floating.left,
+		right: floating.right - clip.right
+	};
+}
+
+export interface OffsetOptions {
+	mainAxis?: number;
+}
+
+/** Displaces the floating element away from the reference along the side axis. */
+export function offset(value: number | OffsetOptions = 0): Middleware {
+	const mainAxis = typeof value === 'number' ? value : (value.mainAxis ?? 0);
+	return {
+		name: 'offset',
+		fn(state) {
+			const { x, y, placement } = state;
+			switch (getSide(placement)) {
+				case 'top':
+					return { y: y - mainAxis };
+				case 'bottom':
+					return { y: y + mainAxis };
+				case 'left':
+					return { x: x - mainAxis };
+				case 'right':
+					return { x: x + mainAxis };
+				default:
+					return {};
+			}
+		}
+	};
+}
+
+export interface FlipOptions {
+	padding?: number;
+	crossAxis?: boolean;
+	fallbackPlacements?: Placement[];
+	fallbackAxisSideDirection?: 'none' | 'start' | 'end';
+}
+
+function getOppositeAxisPlacements(placement: Placement, direction: 'start' | 'end'): Placement[] {
+	const alignment = getAlignment(placement);
+	let list: Side[] = getSideAxis(placement) === 'y' ? ['left', 'right'] : ['top', 'bottom'];
+	if (direction === 'end') list = [...list].reverse();
+	return list.map((s) => (alignment ? (`${s}-${alignment}` as Placement) : (s as Placement)));
+}
+
+/** Swaps to the opposite (or a fallback) placement when the current one overflows. */
+export function flip(options: FlipOptions = {}): Middleware {
+	const {
+		padding = 0,
+		crossAxis: checkCrossAxis = true,
+		fallbackPlacements,
+		fallbackAxisSideDirection = 'none'
+	} = options;
+
+	return {
+		name: 'flip',
+		fn(state) {
+			const { placement, initialPlacement, middlewareData } = state;
+			const data = middlewareData.flip ?? {};
+
+			const placements: Placement[] = data.placements ?? [
+				initialPlacement,
+				...(fallbackPlacements ?? [
+					getOppositePlacement(initialPlacement),
+					...(fallbackAxisSideDirection !== 'none'
+						? getOppositeAxisPlacements(initialPlacement, fallbackAxisSideDirection)
+						: [])
+				])
+			];
+
+			const overflow = detectOverflow(state, padding);
+			const side = getSide(placement);
+
+			// Track overflow on the main side (and, optionally, the alignment axis).
+			const checks: number[] = [overflow[side]];
+			if (checkCrossAxis) {
+				const alignment = getAlignment(placement);
+				if (alignment) {
+					const alignAxis: Axis = getSideAxis(placement) === 'y' ? 'x' : 'y';
+					const a: Side = alignAxis === 'x' ? 'left' : 'top';
+					const b: Side = alignAxis === 'x' ? 'right' : 'bottom';
+					checks.push(overflow[a], overflow[b]);
+				}
+			}
+
+			const overflows = [...(data.overflows ?? []), { placement, overflow: overflow[side] }];
+
+			if (!checks.every((o) => o <= 0)) {
+				const nextIndex = (data.index ?? 0) + 1;
+				const nextPlacement = placements[nextIndex];
+				if (nextPlacement) {
+					return {
+						data: { index: nextIndex, overflows, placements },
+						reset: { placement: nextPlacement }
+					};
+				}
+				// Nothing fit on its main side: fall back to whichever overflowed least.
+				const best = [...overflows].sort((p, q) => p.overflow - q.overflow)[0]?.placement;
+				if (best && best !== placement) {
+					return { data: { placements }, reset: { placement: best } };
+				}
+			}
+
+			return {};
+		}
+	};
+}
+
+export interface ShiftOptions {
+	padding?: number;
+	crossAxis?: boolean;
+	mainAxis?: boolean;
+}
+
+/** Slides the floating element to keep it within the viewport. */
+export function shift(options: ShiftOptions = {}): Middleware {
+	const { padding = 0, crossAxis = false, mainAxis = true } = options;
+	return {
+		name: 'shift',
+		fn(state) {
+			const { x, y, placement } = state;
+			const overflow = detectOverflow(state, padding);
+			const coords = { x, y };
+
+			// The "main" shift axis is perpendicular to the side axis.
+			const mainShiftAxis: Axis = getSideAxis(placement) === 'y' ? 'x' : 'y';
+
+			const apply = (axis: Axis) => {
+				const minSide: Side = axis === 'x' ? 'left' : 'top';
+				const maxSide: Side = axis === 'x' ? 'right' : 'bottom';
+				const min = coords[axis] + overflow[minSide];
+				const max = coords[axis] - overflow[maxSide];
+				coords[axis] = clamp(min, coords[axis], max);
+			};
+
+			if (mainAxis) apply(mainShiftAxis);
+			if (crossAxis) apply(mainShiftAxis === 'x' ? 'y' : 'x');
+
+			return { x: coords.x, y: coords.y };
+		}
+	};
+}
+
+export interface SizeApplyArgs {
+	availableWidth: number;
+	availableHeight: number;
+	elements: { reference: ReferenceElement; floating: FloatingElement };
+	rects: { reference: Rect; floating: Rect };
+	placement: Placement;
+}
+
+export interface SizeOptions {
+	padding?: number;
+	apply?: (args: SizeApplyArgs) => void;
+}
+
+/** Reports the space available to the floating element so callers can cap its size. */
+export function size(options: SizeOptions = {}): Middleware {
+	const { padding = 0, apply } = options;
+	return {
+		name: 'size',
+		fn(state) {
+			const { placement, rects, elements } = state;
+			const overflow = detectOverflow(state, padding);
+
+			const availableWidth = Math.max(
+				0,
+				rects.floating.width - Math.max(0, overflow.left) - Math.max(0, overflow.right)
+			);
+			const availableHeight = Math.max(
+				0,
+				rects.floating.height - Math.max(0, overflow.top) - Math.max(0, overflow.bottom)
+			);
+
+			apply?.({ availableWidth, availableHeight, elements, rects, placement });
+			return {};
+		}
+	};
+}
+
+/** The floating element's offset parent (containing block) for `absolute` strategy. */
+function getOffsetParent(element: FloatingElement): HTMLElement {
+	const parent = element.offsetParent;
+	if (parent instanceof HTMLElement) return parent;
+	return element.ownerDocument.documentElement;
+}
+
+/**
+ * Positions `floating` relative to `reference`, running the configured
+ * middleware. Async to match `@floating-ui/dom`'s signature.
+ */
+export function computePosition(
+	reference: ReferenceElement,
+	floating: FloatingElement,
+	config: ComputePositionConfig = {}
+): Promise<ComputePositionReturn> {
+	const { placement = 'bottom', strategy = 'absolute', middleware = [] } = config;
+
+	const referenceRect = getViewportRect(reference);
+	const floatingClientRect = floating.getBoundingClientRect();
+	const floatingRect: Rect = {
+		x: 0,
+		y: 0,
+		width: floatingClientRect.width,
+		height: floatingClientRect.height
+	};
+
+	const validMiddleware = middleware.filter(Boolean) as Middleware[];
+	const middlewareData: MiddlewareData = {};
+
+	let statePlacement = placement;
+	let { x, y } = computeCoordsFromPlacement(referenceRect, floatingRect, statePlacement);
+
+	let i = 0;
+	let resets = 0;
+	while (i < validMiddleware.length) {
+		const mw = validMiddleware[i];
+		const result =
+			mw.fn({
+				x,
+				y,
+				initialPlacement: placement,
+				placement: statePlacement,
+				strategy,
+				rects: { reference: referenceRect, floating: floatingRect },
+				elements: { reference, floating },
+				middlewareData
+			}) ?? {};
+
+		if (result.x != null) x = result.x;
+		if (result.y != null) y = result.y;
+		if (result.data) {
+			middlewareData[mw.name] = { ...middlewareData[mw.name], ...result.data };
+		}
+
+		if (result.reset && resets < 50) {
+			resets++;
+			if (typeof result.reset === 'object' && result.reset.placement) {
+				statePlacement = result.reset.placement;
+			}
+			({ x, y } = computeCoordsFromPlacement(referenceRect, floatingRect, statePlacement));
+			i = 0;
+			continue;
+		}
+
+		i++;
+	}
+
+	if (strategy === 'absolute') {
+		const offsetParent = getOffsetParent(floating);
+		const opRect = offsetParent.getBoundingClientRect();
+		x = x - opRect.left - offsetParent.clientLeft + offsetParent.scrollLeft;
+		y = y - opRect.top - offsetParent.clientTop + offsetParent.scrollTop;
+	}
+
+	return Promise.resolve({ x, y, placement: statePlacement, strategy, middlewareData });
+}
+
+export { sides };

--- a/packages/silk/src/utils.ts
+++ b/packages/silk/src/utils.ts
@@ -7,7 +7,7 @@ import {
 	size,
 	type Placement,
 	type ReferenceElement
-} from '@floating-ui/dom';
+} from './internals/floating';
 import type { Snippet } from 'svelte';
 import { twMerge } from 'tailwind-merge';
 

--- a/turbo.json
+++ b/turbo.json
@@ -8,14 +8,20 @@
 		},
 		"build": {
 			"dependsOn": ["^build", "check"],
-			"outputs": ["build/**", ".svelte-kit/**", "dist/**", "prisma/generated/**"]
+			"outputs": [
+				"build/**",
+				".svelte-kit/**",
+				"dist/**",
+				"prisma/generated/**",
+				".vercel/output/**"
+			]
 		},
 		"check": {
 			"dependsOn": ["^check"]
 		},
 		"generate": {
 			"inputs": ["prisma/schema.prisma", "prisma.config.ts"],
-			"outputs": ["prisma/generated/**"]
+			"outputs": ["prisma/generated/**", ".vercel/output/**"]
 		},
 		"lint": {},
 		"test": {


### PR DESCRIPTION
Closes #67.

Replaces the `@floating-ui/dom` dependency with a small, built-in positioning engine.

## New engine — `packages/silk/src/internals/floating.ts`
A dependency-free implementation of exactly the floating-ui surface Silk uses:
- `computePosition(reference, floating, { placement, strategy, middleware })`
- middleware: `offset`, `flip`, `shift`, `size`
- types: `Placement`, `ReferenceElement`, `VirtualElement` (plus supporting types)

Public shapes mirror floating-ui so **call sites are unchanged**. Middleware run in viewport coordinates (simple overflow detection), then the result is converted into the floating element's containing block for the `absolute` strategy; `fixed` returns viewport coordinates as-is. Both strategies are used in the codebase (`absolute` via `positionFloatingPanel` for popover/select/dropdown/context-menu/hover-card/combobox; `fixed` for the tooltip).

## Wiring
- Repointed `utils.ts`, `tooltip/shared-tooltip.ts`, and the `VirtualElement`/`ReferenceElement` type imports in popover, context-menu, marquee-popover.
- Removed the dead `computePosition/flip` imports in the combobox parts (they delegated positioning to `Popover.Content`).
- Dropped `@floating-ui/dom` from both `package.json` files and the four component manifests; refreshed the manifest prose.

## Verification
- **New unit test** `floating.test.ts` (10 tests) deterministically verifies base placements, start/end alignment, `offset`, `flip` (overflow → opposite side), `shift` (clamp into viewport), and `size`.
- Full non-browser suite: **481 unit/ssr tests pass**; `svelte-check` 0 errors; `eslint`/prettier clean.
- The existing popover/select/tooltip/context-menu/hover-card **browser tests** exercise real positioning and run in CI.

### Reviewer note
Pixel-exact positioning couldn't be visually verified in the dev sandbox (Playwright Chromium can't be downloaded behind the proxy — see #94). The engine's math is unit-tested and the behavioral browser tests cover the lifecycle/positioning-applied paths in CI, but a quick visual pass on popovers/menus/tooltips near viewport edges before merge is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PhZLyPYuZEuhcVT9qtvSQ)_